### PR TITLE
script names: fix path and descriptions

### DIFF
--- a/src/scripts/rpm-ostree-toolbox-build-monitor
+++ b/src/scripts/rpm-ostree-toolbox-build-monitor
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# rpm-ostree-build-monitor - listen on koji message bus, trigger compose
+# rpm-ostree-toolbox-build-monitor - listen on koji message bus, trigger compose
 #
 # This tool is part of the ostree build process. It is intended to
 # run 24x7, probably via systemd on a fixed internal host. It monitors

--- a/src/systemd/rpm-ostree-toolbox-kinit.timer
+++ b/src/systemd/rpm-ostree-toolbox-kinit.timer
@@ -1,6 +1,6 @@
 [Unit]
-Description=rpm-ostree-kinit timer
+Description=rpm-ostree-toolbox-kinit timer
 
 [Timer]
 OnUnitInactiveSec=2h
-Unit=rpm-ostree-kinit.service
+Unit=rpm-ostree-toolbox-kinit.service


### PR DESCRIPTION
b170c7c renamed scripts into our namespace. A few got missed.
