### PR TITLE
Two small fixes:

### DIFF
--- a/src/py/rpmostreecompose/imagefactory.py
+++ b/src/py/rpmostreecompose/imagefactory.py
@@ -128,7 +128,8 @@ class ImageFactoryTask(TaskBase):
             os.makedirs(imagedir)
 
         imagestmpdir = os.path.join(self.workdir, 'images')
-        os.mkdir(imagestmpdir)
+        if not os.path.exists(imagestmpdir):
+            os.mkdir(imagestmpdir)
 
         generated = []
 

--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -26,6 +26,7 @@ import subprocess
 import distutils.spawn
 from gi.repository import Gio, OSTree, GLib
 import iniparse
+from .utils import fail_msg
 
 class TaskBase(object):
     ATTRS = [ 'outputdir', 'workdir', 'rpmostree_cache_dir', 'pkgdatadir', 'ostree_repo',


### PR DESCRIPTION
1) [taskbase] import fail_msg module so failure to find config
   file is properly displayed to stdout
2) [imagefactory] added conditional to check if imagestmpdir
   exists prior to the mkdir()
