### PR TITLE
taskbase: Use values from ini, override with json

### DIFF
--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -32,7 +32,8 @@ class TaskBase(object):
     ATTRS = [ 'outputdir', 'workdir', 'rpmostree_cache_dir', 'pkgdatadir', 'ostree_repo',
               'os_name', 'os_pretty_name',
               'tree_name', 'tree_file', 'arch', 'release', 'ref',
-              'yum_baseurl', 'lorax_additional_repos', 'local_overrides', 'http_proxy'
+              'yum_baseurl', 'lorax_additional_repos', 'local_overrides', 'http_proxy',
+              'selinux'
             ]
 
     def __init__(self, configfile, name=None, kickstart=None, release=None,
@@ -41,11 +42,14 @@ class TaskBase(object):
         self._name = name
         self._tdl = tdl
         self._kickstart = kickstart
+
+
         assert release is not None
         defaults = { 'workdir': None,
                      'pkgdatadir':  os.environ['OSTBUILD_DATADIR'],
                      'yum_baseurl': None,
-                     'local_overrides': None
+                     'local_overrides': None,
+                     'selinux': True
                    }
 
         if not os.path.exists(configfile):
@@ -63,6 +67,9 @@ class TaskBase(object):
                     val = defaults.get(attr)
             setattr(self, attr, val)
 
+        if self.tree_file is None:
+            fail_msg("No tree file was provided")
+
         if not self.yum_baseurl:
             if self.release in [ '21', 'rawhide' ]:
                 self.yum_baseurl = 'http://download.fedoraproject.org/pub/fedora/linux/development/%s/%s/os/' % (self.release, self.arch)
@@ -77,14 +84,80 @@ class TaskBase(object):
             self.workdir = tempfile.mkdtemp('.tmp', 'atomic-treecompose')
             self.workdir_is_tmp = True
 
+        self.buildjson()
+
         return
+    
+    def flattenjsoninclude(self, params):
+        """ This function merges a dict that represents a tree file
+        with a json includefile. It's not rescursive now but could be
+        made to be.
+        """
+        includefile = (os.path.dirname(self.tree_file)) + "/" + params['include']
+        params.pop('include', None)
+        if not os.path.isfile(includefile):
+            fail_msg(("Your tree file includes another file %s that could not be found") % includefile)
+        else:
+            jsoninclude = open(includefile)
+            incparams = json.load(jsoninclude)
+            for key in incparams:
+                # If its a str,bool,or list and doesn't exist, add it
+                if (key not in params) and (key != "comment"):
+                    params[key] = incparams[key]
+                # If its a list and already exists, merge them 
+                if key in params and type(incparams[key]) == list:
+                    merged = list(set(params[key] + incparams[key]))
+                    params[key] = merged
+        return params
+
+    def buildjson(self):
+        """ This function merges content from the config.ini and
+        the json treefile and then outputs a merged, temporary
+        json file in tempdir 
+        """
+
+        json_in = open(self.tree_file)
+        params = json.load(json_in)
+        if 'ref' not in 'params':
+            params['ref']  = self.ref
+        if 'selinux' not in 'params':
+            params['selinux'] = self.selinux
+        if 'osname' not in 'params':
+            params['osname'] = self.os_name
+        if 'include' in params:
+            params = self.flattenjsoninclude(params)
+
+        # Need to flatten repos
+        if 'repos' in params:
+            self._copyrepos(params['repos'])
+        #self.jsonfile = tempfile.NamedTemporaryFile(prefix='atomic', suffix='.json', delete=False, dir=self.workdir)
+        #self.jsonfilename = self.jsonfile.name
+        self.jsonfilename = os.path.join(self.workdir, os.path.basename(self.tree_file))
+        self.jsonfile = open(self.jsonfilename, 'w')
+        json.dump(params, self.jsonfile, indent=4)
+        self.jsonfile.close()
+
+    def _copyrepos(self, repos):
+        """
+        This function takes a list of repository names, iterates
+        through them and copies them to tempdir
+        """
+
+        for i in repos:
+            if not os.path.exists(i + ".repo"):
+                fail_msg("Unable to find %s as declared in the json input file(s)" % i+".repo")
+            try:
+                shutil.copyfile(i + ".repo", "{0}/{1}.repo".format(self.workdir, i))
+            except:
+                fail_msg("Unable to copy {0} to tempdir".format(i))
 
     @property
     def repo(self):
         if not os.path.exists(self.ostree_repo):
             #  Remove the cache, if the repo. is gone ... or rpm-ostree is very
             # confused.
-            shutil.rmtree(self.rpmostree_cache_dir)
+            if os.path.exists(self.rpmostree_cache_dir):
+                shutil.rmtree(self.rpmostree_cache_dir)
             os.makedirs(self.ostree_repo)
             subprocess.check_call(['ostree', 'init',
                                    "--repo="+self.ostree_repo])

--- a/src/py/rpmostreecompose/treecompose.py
+++ b/src/py/rpmostreecompose/treecompose.py
@@ -45,7 +45,7 @@ class Treecompose(TaskBase):
             rpmostreecmd.append(cachecmd)
             if not os.path.exists(rpmostreecachedir):
                 os.makedirs(rpmostreecachedir)
-        rpmostreecmd.append(self.tree_file)
+        rpmostreecmd.append(self.jsonfilename)
 
         subprocess.check_call(rpmostreecmd)
         _,newrev = self.repo.resolve_rev(self.ref, True)


### PR DESCRIPTION
taskbase: Flatten json file(s) input to tempdir
taskbase: copy repo file(s) to tempdir

Certain required variables in ini files like ref were unused in
tree composes.  These fixes result in using setting a rule that
if the value is in the ini file, use it but it can be overriden
by input from a json file.  The ini variable is then added to a
temporary json file that is stored in a tempdir and consumed by
'rpm-ostree compose tree'.

Along with adding the ini content to the json file, a function
was also added to detect if the json file has an include
statement.  If so, it will inherit the included json file
content and merge the two with the following rules:

```
* if the key value doesn't exist in the json, add it
* if the key value is a list and does exist, merge and
  remove duplicates.
```

And finally, to make processing for 'rpm-ostree tree compose'
easier, the detected repo files are copied to the temp dir.
