### PR TITLE
    treecompose: Make -c optional and set config.ini to default

### DIFF
--- a/src/py/rpmostreecompose/treecompose.py
+++ b/src/py/rpmostreecompose/treecompose.py
@@ -55,7 +55,7 @@ class Treecompose(TaskBase):
 
 def main():
     parser = argparse.ArgumentParser(description='Compose OSTree tree')
-    parser.add_argument('-c', '--config', type=str, required=True, help='Path to config file')
+    parser.add_argument('-c', '--config', type=str, default='config.ini', help='Path to config file')
     parser.add_argument('-r', '--release', type=str, default='rawhide', help='Release to compose (references a config file section)')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
     args = parser.parse_args()


### PR DESCRIPTION
```
Changed -c to be optional and set config.ini to be the default
config file used in treecomposes.  This nearly allows users to
run treecompose with the stock git fedora-atomic git repo.
```
