### PR TITLE
treecompose: add ability to output rhev and vsphere images

### DIFF
--- a/packaging/rpm-ostree-toolbox.spec.in
+++ b/packaging/rpm-ostree-toolbox.spec.in
@@ -33,8 +33,11 @@ Requires: kernel
 
 Requires: lorax
 # Imagefactory
-Requires: imagefactory
-Requires: imagefactory-plugins-TinMan
+Requires: imagefactory >= 1.1.6-1
+Requires: imagefactory-plugins-TinMan >= 1.1.6-1
+Requires: imagefactory-plugins-OVA >= 1.1.6-1
+Requires: imagefactory-plugins-vSphere >= 1.1.6-1
+Requires: imagefactory-plugins-RHEVM >= 1.1.6-1
 
 %if 0%{?rhel}
 %else

--- a/src/py/rpmostreecompose/imagefactory.py
+++ b/src/py/rpmostreecompose/imagefactory.py
@@ -25,7 +25,9 @@ import shutil
 import subprocess
 import distutils.spawn
 from gi.repository import Gio, OSTree, GLib
-import iniparse
+from iniparse import INIConfig
+
+from imgfac.PersistentImageManager import PersistentImageManager
 
 # For ImageFactory builds
 from imgfac.BuildDispatcher import BuildDispatcher
@@ -36,6 +38,7 @@ import logging
 from .taskbase import TaskBase
 
 from .utils import run_sync, fail_msg
+
 
 class ImgBuilder(object):
     '''
@@ -60,11 +63,13 @@ class ImgBuilder(object):
         '''
         raise NotImplementedError
 
+
 class ImgFacBuilder(ImgBuilder):
     def __init__(self, *args, **kwargs):
         config = json.loads(open('/etc/imagefactory/imagefactory.conf').read())
         config['plugins'] = '/etc/imagefactory/plugins.d'
         config['timeout'] = 3600
+        config['rhevm_image_format'] = 'qcow2'
         ApplicationConfiguration(configuration=config)
         plugin_mgr = PluginManager('/etc/imagefactory/plugins.d')
         plugin_mgr.load()
@@ -76,6 +81,14 @@ class ImgFacBuilder(ImgBuilder):
         self.tlog = logging.getLogger()
         self.tlog.setLevel(logging.DEBUG)
         self.tlog.addHandler(self.fhandler)
+ 
+        global verbosemode
+        if verbosemode:
+            ch = logging.StreamHandler(sys.stdout)
+            ch.setLevel(logging.DEBUG)
+            formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            ch.setFormatter(formatter)
+            self.tlog.addHandler(ch)
 
         pass
 
@@ -93,10 +106,39 @@ class ImgFacBuilder(ImgBuilder):
 
         if image.status != "COMPLETE":
             fail_msg("Failed image status: " + image.status)
-        return image.data
+        return image
+
+    def buildimagetype(self, imagetype, baseid, imgopts={}):
+        """
+        This method compliments the builder method by taking its
+        uuid and outputputting various image formats
+        """
+        print "Working on a {0} for {1}".format(imagetype, baseid)
+        bd = BuildDispatcher()
+        imagebuilder = bd.builder_for_target_image(imagetype, image_id=baseid, template=None, parameters=imgopts)
+        target_image = imagebuilder.target_image
+        thread = imagebuilder.target_thread
+        thread.join()
+        if target_image.status != "COMPLETE":
+            fail_msg("Failed image status: " + target_image.status)
+
+        print target_image.identifier
+        # Now doing the OVA
+
+        print "Creating OVA for {0}".format(imagetype)
+
+        bdi = BuildDispatcher()
+        ovabuilder = bdi.builder_for_target_image("ova", image_id=target_image.identifier, template=None, parameters=imgopts)
+        target_ova = ovabuilder.target_image
+        ovathread = ovabuilder.target_thread
+        ovathread.join()
+        if target_ova.status != "COMPLETE":
+            fail_msg("Failed image status: " + target_ova.status)
+        return target_ova
 
     def download(self):
         pass
+
 
 class KojiBuilder(ImgBuilder):
     def __init__(self, **kwargs):
@@ -115,18 +157,18 @@ class KojiBuilder(ImgBuilder):
 
 
 class ImageFactoryTask(TaskBase):
-    def create(self, outputdir, name, ksfile, tdl):
+    def create(self, outputdir, name, ksfile, tdl, imageouttypes):
         self._name = name
         self._tdl = tdl
         self._kickstart = ksfile 
 
-        [res,rev] = self.repo.resolve_rev(self.ref, False)
-        [res,commit] = self.repo.load_variant(OSTree.ObjectType.COMMIT, rev)
+        [res, rev] = self.repo.resolve_rev(self.ref, False)
+        [res, commit] = self.repo.load_variant(OSTree.ObjectType.COMMIT, rev)
 
         commitdate = GLib.DateTime.new_from_unix_utc(OSTree.commit_get_timestamp(commit)).format("%c")
         print commitdate
 
-        target=os.path.join(outputdir, '%s.raw' % (self._name))
+        target = os.path.join(outputdir, '%s.raw' % (self._name))
 
         port_file_path = self.workdir + '/repo-port'
         subprocess.check_call(['ostree',
@@ -156,15 +198,58 @@ class ImageFactoryTask(TaskBase):
         for subname, subval in substitutions.iteritems():
             ksdata = ksdata.replace('@%s@' % (subname, ), subval)
 
-        parameters =  { "install_script": ksdata, 
+        parameters =  { "install_script": ksdata,
                         "generate_icicle": False,
                       }
-
+        defaultimagetype = checkoz()
         print "Starting build"
-        image_path = self.builder.build(template=open(self._tdl).read(),
-                                        parameters=parameters)
-        shutil.copyfile(image_path, target)
+        image = self.builder.build(template=open(self._tdl).read(), parameters=parameters)
+
+        # For debug, you can comment out the above and enable the code below
+        # to skip the initial image creation.  Just point myuuid at the proper
+        # image uuid
+
+        # self.builder.download()
+        # myuuid = "32a2d0b8-da84-415c-aec6-90bb5a7f8e8b"
+        # pim = PersistentImageManager.default_manager()
+        # image = pim.image_with_id(myuuid)
+
+        # This should probably be broken out to a sep. function
+
+        if defaultimagetype == "raw": 
+
+            # Always create a qcow2
+
+            print "Processing image from raw to qcow2"
+            print image.data
+            outputname = os.path.join(outputdir, '%s.qcow2' % (self._name))
+            print outputname
+
+            qemucmd = ['qemu-img', 'convert', '-f', 'raw', '-O', 'qcow2', image.data, outputname]
+            imageouttypes.pop(imageouttypes.index("kvm"))
+            subprocess.check_call(qemucmd)
+
+        if 'kvm' in imageouttypes:
+            print "Processing image from qcow2 to raw"
+            print image.data
+            outputname = os.path.join(outputdir, '%s.raw' % (self._name))
+            print outputname 
+
+            qemucmd = ['qemu-img', 'convert', '-f', 'raw', '-O', 'qcow2', image.data, outputname]
+            imageouttypes.pop(imageouttypes.index("raw"))
+            subprocess.check_call(qemucmd))
+        
+        
+
+        shutil.copyfile(image.data, target)
         print "Created: " + target
+
+        for imagetype in imageouttypes:
+            print "Creating {0} image".format(imagetype)
+            target_image = self.builder.buildimagetype(imagetype, image.identifier)
+            infile = target_image.data
+            outfile = os.path.join(outputdir, '%s-%s.ova' % (self._name, imagetype))
+            shutil.copyfile(infile, outfile)
 
     @property
     def builder(self):
@@ -176,9 +261,55 @@ class ImageFactoryTask(TaskBase):
 
 ## End Composer
 
+
+def checkoz():
+    """
+    Method which checks the oz.cfg for certain variables to alert
+    user to potential errors caused by the cfg itself. It also
+    returns the default image type.
+    """
+    cfg = INIConfig(open('/etc/oz/oz.cfg'))
+    if cfg.libvirt.image_type == "qcow2":
+        print" The default image type in /etc/oz/oz.cfg must be 'raw'.  Please correct this and rerun rpm-ostree-toolbox."
+        exit(1)
+    else:
+        print "Your default image will be of {0} format".format(cfg.libvirt.image_type)
+
+    # iniparse returns an object if it cannot find the config option
+    # we check if the the return is a str and assume if not, it does
+    # not exist
+
+    if not isinstance(cfg.libvirt.memory, str):
+        print "Your current configuration in /etc/oz/oz.cfg does not define a memory amount for libvirt.  Consider defining it to at least 2048 to avoid image creation failures"
+        exit(1)
+    else:
+        if int(cfg.libvirt.memory) < 2049:
+            print "Your current oz configuration specifies a memory amount of less than 2048 which can lead to possible image creation failures."
+            exit(1)
+    return cfg.libvirt.image_type
+
+def parseimagetypes(imagetypes):
+    default_image_types = ["kvm", "raw", "vsphere", "rhevm"]
+    if imagetypes == None:
+        return default_image_types
+
+    # Check that input types are valid
+    for i in imagetypes:
+        if i not in default_image_types:
+            print "{0} is not a valid image type.  The valid types are {1}".format(i, default_image_types)
+            exit(1) 
+
+    if 'kvm' not in imagetypes:
+        print "An image type of 'kvm'. Adding kvm as an image type."
+        imagetypes.append("kvm")
+
+    return imagetypes
+
+
 def main():
     parser = argparse.ArgumentParser(description='Use ImageFactory to create a disk image')
-    parser.add_argument('-c', '--config', type=str, required=True, help='Path to config file')
+    parser.add_argument('-c', '--config', default='config.ini', type=str, help='Path to config file')
+    parser.add_argument('-i', '--images', help='Output image formats in list format', action='append')
     parser.add_argument('--name', type=str, required=True, help='Image name') 
     parser.add_argument('--tdl', type=str, required=True, help='TDL file') 
     parser.add_argument('-o', '--outputdir', type=str, required=True, help='Path to image output directory')
@@ -186,14 +317,19 @@ def main():
     parser.add_argument('-r', '--release', type=str, default='rawhide', help='Release to compose (references a config file section)')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
     args = parser.parse_args()
+     
+    imagetypes = parseimagetypes(args.images)
 
     composer = ImageFactoryTask(args.config, release=args.release)
     composer.show_config()
-
+    global verbosemode
+    verbosemode = args.verbose
     try:
         composer.create(outputdir=args.outputdir,
                         name=args.name,
                         ksfile=args.kickstart,
-                        tdl=args.tdl)
+                        tdl=args.tdl,
+                        imageouttypes=imagetypes
+                        )
     finally:
         composer.cleanup()


### PR DESCRIPTION
rpm-ostree-toolbox.spec.in: add new imagefactory-plugin deps and versions

Treecompose will now output multiple image flavors.  They are:

```
* kvm (qcow2), raw, rhev (ova), vsphere (ova)
```

The above images will be the default outputs. If you pass a -i or
--images, you can override the ouputs.  For each image desired, you
pass an additional -i.  Treecompose will always output a qcow2.

For now, treecompose will require the default oz image_type to be raw
because imagefactory (for now) requires this for input on image
conversation.  When that is fixed, we then make raw no longer required.

Additionally, the -c option is no longer required. If not provided,
we look for config.ini.

And finally, there a some new exit conditions for treecompose.  We now
check the oz config for the image_type and a minimum RAM recommendation.
If those are not met, the script will exit with a stdout error message.
This is done so that consumer tools like koji/brew have the error at the
ready.
