### PR TITLE
treecompose: Support the new ostree --output-repodata-dir

### DIFF
--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -33,7 +33,7 @@ class TaskBase(object):
               'os_name', 'os_pretty_name',
               'tree_name', 'tree_file', 'arch', 'release', 'ref',
               'yum_baseurl', 'lorax_additional_repos', 'local_overrides', 'http_proxy',
-              'selinux'
+              'selinux', 'output_repodata_dir',
             ]
 
     def __init__(self, configfile, release=None):
@@ -43,6 +43,7 @@ class TaskBase(object):
         defaults = { 'workdir': None,
                      'pkgdatadir':  os.environ['OSTBUILD_DATADIR'],
                      'yum_baseurl': None,
+                     'output_repodata_dir': None,
                      'local_overrides': None,
                      'selinux': True
                    }

--- a/src/py/rpmostreecompose/treecompose.py
+++ b/src/py/rpmostreecompose/treecompose.py
@@ -116,6 +116,9 @@ class Treecompose(TaskBase):
                 os.makedirs(rpmostreecachedir)
         rpmostreecmd.append(self.jsonfilename)
 
+        if self.output_repodata_dir:
+            rpmostreecmd.append('--output-repodata-dir=' + self.output_repodata_dir)
+
         subprocess.check_call(rpmostreecmd)
         _,newrev = self.repo.resolve_rev(self.ref, True)
         return (origrev, newrev)


### PR DESCRIPTION
This adds a configuration option for the new `ostree --output_repodata_dir` added in https://github.com/projectatomic/rpm-ostree/commit/e6c42cb8841a6f60e12e1eed430f8e42e14a242b
