### PR TITLE
Allow 1.2.3 versions as well as 1.2.3.4

### DIFF
--- a/src/py/rpmostreecompose/treecompose.py
+++ b/src/py/rpmostreecompose/treecompose.py
@@ -65,15 +65,16 @@ class Treecompose(TaskBase):
 
         try:
             lv = [int(x) for x in loaded_version.split('.', 3)]
+            lv[2] # Make sure there are at least 3 (1.2.3) numbers
         except:
             print >>sys.stderr, " WARNING: Old version is invalid (not 4 numbers)."
             loaded_version = None
 
         if self.tree_version:
 
-            # Version looks like <releasever>.<minor>.<refresh>.<cve>
+            # Version looks like <releasever>.<minor>.<refresh>[.<cve>]
             # So if we are on 1.2.4.8 then:
-            # --version=minor   == 1.3.0.0
+            # --version=minor   == 1.3.0
             # --version=refresh == 1.2.5.0
             # --version=cve     == 1.2.4.9
             if not loaded_version and self.tree_version in ('cve', 'minor',
@@ -86,29 +87,42 @@ class Treecompose(TaskBase):
             if loaded_version and self.tree_version == 'refresh':
                 lv = [int(x) for x in loaded_version.split('.')]
                 lv[2] += 1
-                lv[3] = 0
-                self.tree_version = "%u.%u.%u.%u" % tuple(lv)
+                if len(lv) > 3:
+                    del lv[3]
+                self.tree_version = "%u.%u.%u" % tuple(lv)
             if loaded_version and self.tree_version == 'minor':
                 lv = [int(x) for x in loaded_version.split('.')]
                 lv[1] += 1
                 lv[2] = 0
-                lv[3] = 0
-                self.tree_version = "%u.%u.%u.%u" % tuple(lv)
+                if len(lv) > 3:
+                    del lv[3]
+                self.tree_version = "%u.%u.%u" % tuple(lv)
 
             tv = self.tree_version.split('.')
-            if len(tv) != 4:
-                fail_msg("Version not in correct format (4 numbers). Eg. version=1.2.3.4")
+            if len(tv) not in (3, 4):
+                fail_msg("Version not in correct format (3-4 numbers). Eg. version=1.2.3.4")
 
             if loaded_version:
                 lv = [int(x) for x in loaded_version.split('.')]
 
-                if int(tv[0]) < lv[0]:
+                if False: pass
+                elif int(tv[0]) < lv[0]:
                     fail_msg("<releasever> of version is getting older.")
-                if int(tv[1]) < lv[1]:
+                elif int(tv[0]) > lv[0]:
+                    pass
+                elif int(tv[1]) < lv[1]:
                     fail_msg("<minor> of version is getting older.")
-                if int(tv[2]) < lv[2]:
+                elif int(tv[1]) > lv[1]:
+                    pass
+                elif int(tv[2]) < lv[2]:
                     fail_msg("<refresh> of version is getting older.")
-                if int(tv[3]) < lv[3]:
+                elif int(tv[2]) > lv[2]:
+                    pass
+                elif len(tv) == 3 and len(lv) == 4:
+                    fail_msg("<cve> of version doesn't exist.")
+                elif len(tv) >= 3 and len(lv) == 3:
+                    pass
+                elif int(tv[3]) < lv[3]:
                     fail_msg("<cve> of version is getting older.")
             print "** Building Version:", self.tree_version
             rpmostreecmd.append('--add-metadata-string=version=' + self.tree_version)


### PR DESCRIPTION
Also make refresh and minor autoversions have a blank cve instead of 0.

Also fixes bugs in the number checking, in that before we'd fail on:

old=1.2.3.4, new=2.1.1.1
