### PR TITLE
treecompose: Add ability to automatically detect atomic host IP

### DIFF
--- a/packaging/rpm-ostree-toolbox.spec.in
+++ b/packaging/rpm-ostree-toolbox.spec.in
@@ -26,6 +26,7 @@ Requires: python
 Requires: python-iniparse
 Requires: pygobject2
 Requires: gjs
+Requires: libvirt-python
 Requires: libguestfs-tools-c
 Requires: libguestfs-gobject
 # Needed for libguests


### PR DESCRIPTION
When creating imagefactory images, we now detect if there is a "default"
KVM network and if so, we grab its IP and dynamically substitute it into
the KS file.  This prevents a difficult to debug error for users who
use a different IP/subnet scheme on their KVM networks.

If we cannot detect the network and IP, we suggest the user static define
it in the KS file.

packaging/rpm-ostree-toolbox.spec.in: Added libvirt-python as a runtime
dependancy.
