### PR TITLE
rpm-ostree-toolbox: Allow users to run all commands without inputs

### DIFF
--- a/src/py/rpmostreecompose-main
+++ b/src/py/rpmostreecompose-main
@@ -43,13 +43,16 @@ if __name__ == '__main__':
     print "%r" % (sys.argv, )
     if len(sys.argv) <= 1:
         usage(False)
+    if os.getuid() != 0:
+        print "\nrpm-ostee-toolbox requires you to run as root"
+        exit(1)
     cmd = sys.argv.pop(1)
     if cmd == 'imagefactory':
-        imagefactory.main()
+        imagefactory.main(cmd)
     elif cmd == 'installer':
-        installer.main()
+        installer.main(cmd)
     elif cmd == 'treecompose':
-        treecompose.main()
+        treecompose.main(cmd)
     elif cmd == 'taskrunner':
         taskrunner.main()
     elif cmd in ['create-vm-disk', 'postprocess-disk', 'trivial-autocompose']:

--- a/src/py/rpmostreecompose/installer.py
+++ b/src/py/rpmostreecompose/installer.py
@@ -93,16 +93,16 @@ class InstallerTask(TaskBase):
 
 ## End Composer
 
-def main():
+def main(cmd):
     parser = argparse.ArgumentParser(description='Create an installer image')
-    parser.add_argument('-c', '--config', type=str, required=True, help='Path to config file')
-    parser.add_argument('-r', '--release', type=str, default='rawhide', help='Release to compose (references a config file section)')
+    parser.add_argument('-b', '--yum_baseurl', type=str, required=False, help='Full URL for the yum repository')
+    parser.add_argument('-c', '--config', type=str, required=False, default='config.ini', help='Path to config file')
+    parser.add_argument('-p', '--profile', type=str, default='DEFAULT', help='Profile to compose (references a stanza in the config file)')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
     parser.add_argument('--post', type=str, help='Run this %%post script in interactive installs')
-    parser.add_argument('-o', '--outputdir', type=str, required=True, help='Path to image output directory')
+    parser.add_argument('-o', '--outputdir', type=str, required=False, help='Path to image output directory')
     args = parser.parse_args()
-
-    composer = InstallerTask(args.config, release=args.release)
+    composer = InstallerTask(args, cmd, profile=args.profile)
     composer.show_config()
 
     composer.create(args.outputdir, post=args.post)

--- a/src/py/rpmostreecompose/treecompose.py
+++ b/src/py/rpmostreecompose/treecompose.py
@@ -30,6 +30,7 @@ import iniparse
 from .taskbase import TaskBase
 from .utils import run_sync, fail_msg
 
+
 def _rev2version(repo, rev):
     _,oldrev = repo.resolve_rev(rev, True)
     if oldrev is None:
@@ -144,18 +145,16 @@ class Treecompose(TaskBase):
 
 ## End Composer
 
-def main():
+def main(cmd):
     parser = argparse.ArgumentParser(description='Compose OSTree tree')
     parser.add_argument('-c', '--config', type=str, default='config.ini', help='Path to config file')
-    parser.add_argument('-r', '--release', type=str, default='rawhide', help='Release to compose (references a config file section)')
+    parser.add_argument('-p', '--profile', type=str, default='DEFAULT', help='Profile to compose (references a stanza in the config file)')
     parser.add_argument('-V', '--versioning', type=str, default='skip-or-refresh', help='Version to mark compose')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
     args = parser.parse_args()
-
-    composer = Treecompose(args.config, release=args.release)
+    composer = Treecompose(args, cmd, profile=args.profile)
     composer.tree_version = args.versioning
     composer.show_config()
-
     origrev, newrev = composer.compose_tree()
 
     if origrev != newrev:


### PR DESCRIPTION
This patch encompasses several files (of which will be detailed
below) to allow users to run -toolbox commands without additional
commandline switches and only from the configuration file.  It adds
assumptions for finding proper inputs as well as usable fallback
defaults.
- rpm-ostree-toolbox-man
  - Added check for sudo, fail if not
  - Now passing cmd to the classes to help with taskbase conditionals
- treecompose
  - Changed -r (release) to -p (profile) to distinguish between
    the os release and the "stanza" in the configuration file. The
    default setting is now 'DEFAULT'
- imagefactory
  - images (qcow2, etc) are being output'd to outputdir/images
  - -o, -k, --name, --tdl are no longer required
  - Same -r change as treecompose
- installer
  - Same -r change as treecompose
  - -c, -o are no longer required
- taskbase
  - Rec's cmd to be able to conditionally check required inputs
  - profile now is the config.ini stanza
  - release now is the os release, aka release in config.ini
  - detect if -p passed exists, fail otherwise
  - yum_baseurl is now req'd in config.ini or via -b, fallbacks
    removed
  - kickstart fallback is os_name-release.ks
  - tdl fallback is os_name-release.tdl
  - --name is now name from config.ini, unless provided
