### PR TITLE
handle config.ini being a symlink

### DIFF
--- a/src/scripts/rpm-ostree-toolbox-watch
+++ b/src/scripts/rpm-ostree-toolbox-watch
@@ -34,7 +34,7 @@ $| = 1;
 ###############################################################################
 
 use Config::IniFiles;
-use Cwd                 qw(cwd);
+use Cwd                 qw(cwd abs_path);
 use File::Basename      qw(dirname);
 use File::Path          qw(make_path);
 use IO::Select;                                 # for sysreadline()
@@ -495,6 +495,12 @@ sub tree_file {
             or die "$ME: $Config_File: No setting for '$s' in tree_file value '$tree_file'\n";
         $val;
     }ge;
+
+    # If tree_file is a relative path, absolutize it. Make sure we do so
+    # relative to the actual location of $Config_File, which may be a symlink
+    if ($tree_file !~ m|^/|) {
+        $tree_file = dirname(abs_path($Config_File)) . "/" . $tree_file;
+    }
 
     return $tree_file;
 }

--- a/t/src/scripts/rpm-ostree-toolbox-watch/70-start_job.t
+++ b/t/src/scripts/rpm-ostree-toolbox-watch/70-start_job.t
@@ -92,7 +92,7 @@ my $expected_log = <<'EXPECTED_LOG_RE';
 #
 # \d+-\d+-\d+T\d+:\d+:\d+ BEGIN
 
-\$ \(cd atomic && git pull -r\)
+\$ \(cd \S+/atomic && git pull -r\)
 BEGIN \S+/bin/git
   pull
   -r


### PR DESCRIPTION
In particular, if config.ini -> subdir/config.ini and
it defines tree_file = foo.json, make sure we interpret
that as subdir/foo.json
