### PR TITLE
installer images created via libvirt or container

### DIFF
--- a/Makefile-toolbox.am
+++ b/Makefile-toolbox.am
@@ -70,6 +70,8 @@ pytoolboxdatadir = $(pkgdatadir)
 pytoolboxdata_DATA = \
 	src/py/config.ini.sample \
 	src/py/lorax-embed-repo.tmpl \
+	src/py/lorax-http-repo.tmpl \
+	src/py/lorax-indirection-repo.tmpl \
 	$(NULL)
 
 pytoolboxpydir = $(pkglibdir)/py

--- a/packaging/rpm-ostree-toolbox.spec.in
+++ b/packaging/rpm-ostree-toolbox.spec.in
@@ -34,12 +34,14 @@ Requires: kernel
 
 Requires: rpm-ostree
 Requires: lorax
+Requires: docker
 # Imagefactory
 Requires: imagefactory >= 1.1.6-1
 Requires: imagefactory-plugins-TinMan >= 1.1.6-1
 Requires: imagefactory-plugins-OVA >= 1.1.6-1
 Requires: imagefactory-plugins-vSphere >= 1.1.6-1
 Requires: imagefactory-plugins-RHEVM >= 1.1.6-1
+Requires: imagefactory-plugins-IndirectionCloud >= 1.1.6-1
 
 %if 0%{?rhel}
 %else

--- a/src/py/lorax-http-repo.tmpl
+++ b/src/py/lorax-http-repo.tmpl
@@ -1,0 +1,11 @@
+<%page args='root'/>
+mkdir install/ostree
+runcmd ostree --repo=${root}/install/ostree init --mode=archive-z2
+runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-verify=false http://@OSTREE_HOSTIP@:@OSTREE_PORT@
+runcmd ostree --repo=${root}/install/ostree/ pull --mirror ostree-mirror @OSTREE_REF@
+
+
+append usr/share/anaconda/interactive-defaults.ks "ostreesetup --nogpg --osname=@OSTREE_OSNAME@ --remote=@OSTREE_OSNAME@ --url=file:///install/ostree --ref=@OSTREE_REF@\n"
+append usr/share/anaconda/interactive-defaults.ks "services --disabled cloud-init,cloud-config,cloud-final,cloud-init-local\n"
+append usr/share/anaconda/interactive-defaults.ks "%post --erroronfail\nrm -f /etc/ostree/remotes.d/@OSTREE_OSNAME@.conf\n%end\n"
+

--- a/src/py/lorax-indirection-repo.tmpl
+++ b/src/py/lorax-indirection-repo.tmpl
@@ -1,0 +1,24 @@
+<template>
+<files>
+<file name="/root/lorax.tmpl">
+&lt;%page args='root'/&gt;
+mkdir install/ostree
+runcmd ostree --repo=${root}/install/ostree init --mode=archive-z2
+runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-verify=false http://@OSTREE_HOSTIP@:@OSTREE_PORT@
+runcmd ostree --repo=${root}/install/ostree/ pull --mirror ostree-mirror @OSTREE_REF@
+
+
+append usr/share/anaconda/interactive-defaults.ks "ostreesetup --nogpg --osname=@OSTREE_OSNAME@ --remote=@OSTREE_OSNAME@ --url=file:///install/ostree --ref=@OSTREE_REF@\n"
+append usr/share/anaconda/interactive-defaults.ks "services --disabled cloud-init,cloud-config,cloud-final,cloud-init-local\n"
+append usr/share/anaconda/interactive-defaults.ks "%post --erroronfail\nrm -f /etc/ostree/remotes.d/@OSTREE_OSNAME@.conf\n%end\n"
+</file>
+</files>
+<commands>
+   <command name='mount'>mount /dev/vdb1 /mnt</command>
+   <command name="installlorax">yum install -y lorax ostree</command>
+   <command name="makedancry">setenforce 0</command>
+   <command name="lorax">lorax --nomacboot --add-template=/root/lorax.tmpl -p "@OS_PRETTY@" -v @OS_VER@ -r @OS_VER@ @LORAX_REPOS@ /mnt/lorout</command>
+   <command name="makeiancry">tar cvf /mnt/lorout/output.tar -C /mnt/lorout/ images</command>
+</commands>
+</template>
+

--- a/src/py/rpmostreecompose/imagefactory.py
+++ b/src/py/rpmostreecompose/imagefactory.py
@@ -81,8 +81,8 @@ class ImgFacBuilder(ImgBuilder):
         self.tlog = logging.getLogger()
         self.tlog.setLevel(logging.DEBUG)
         self.tlog.addHandler(self.fhandler)
- 
-        global verbosemode
+        verbosemode = kwargs.get('verbosemode', False)
+
         if verbosemode:
             ch = logging.StreamHandler(sys.stdout)
             ch.setLevel(logging.DEBUG)
@@ -235,7 +235,6 @@ class ImageFactoryTask(TaskBase):
             print outputname
 
             qemucmd = ['qemu-img', 'convert', '-f', 'qcow2', '-O', 'raw', image.data, outputname]
-            imageouttypes.pop(imageouttypes.index("raw"))
             subprocess.check_call(qemucmd)
             imageouttypes.pop(imageouttypes.index("raw"))
             print "Created: {0}".format(outputname)
@@ -255,7 +254,8 @@ class ImageFactoryTask(TaskBase):
     def builder(self):
         # TODO: option to switch to koji builder
         if True:
-            return ImgFacBuilder(workdir=self.workdir)
+            global verbosemode
+            return ImgFacBuilder(workdir=self.workdir, verbosemode=verbosemode)
         else:
             return KojiBuilder()
 

--- a/src/py/rpmostreecompose/installer.py
+++ b/src/py/rpmostreecompose/installer.py
@@ -18,93 +18,282 @@
 
 import json
 import os
-import sys
-import tempfile
 import argparse
-import shutil
 import subprocess
-import distutils.spawn
-from gi.repository import Gio, OSTree, GLib
-import iniparse
+import oz.TDL
+import oz.GuestFactory
+import tarfile
 
 from .taskbase import TaskBase
-from .utils import run_sync, fail_msg
+from .utils import fail_msg, run_sync
+from .imagefactory import ImageFunctions
+from .imagefactory import ImgFacBuilder
+from imgfac.BuildDispatcher import BuildDispatcher
+from imgfac.PersistentImageManager import PersistentImageManager
+from xml.etree import ElementTree as ET
+from .imagefactory import getDefaultIP
+
 
 class InstallerTask(TaskBase):
-    def create(self, outputdir, post=None):
-        [res,rev] = self.repo.resolve_rev(self.ref, False)
-        [res,commit] = self.repo.load_variant(OSTree.ObjectType.COMMIT, rev)
+    container_id = ""
 
-        commitdate = GLib.DateTime.new_from_unix_utc(OSTree.commit_get_timestamp(commit)).format("%c")
-        print commitdate
+    def getrepos(self, flatjson):
+        fj = open(flatjson)
+        fjparams = json.load(fj)
+        repos = ""
+        for repo in fjparams['repos']:
+            repofile = os.path.join(getattr(self, 'configdir'), repo + ".repo")
+            repos = repos + open(repofile).read()
+            repos = repos + "enabled=1"
+            repos = repos + "\n"
+        return repos
 
-        lorax_opts = []
-        if self.local_overrides:
-            lorax_opts.extend([ '-s', self.local_overrides ])
+    def template_xml(self, repos, tmplfilename):
+        tree = ET.parse(tmplfilename)
+        root = tree.getroot()
+        files = root.find('files')
+        yumrepos = ET.SubElement(files, "file", {'name': '/etc/yum.repos.d/atomic.repo'})
+        yumrepos.text = repos
+        return ET.tostring(root)
+
+    def dumpTempMeta(self, fullpathname, tmpstr):
+        tmp_file = open(fullpathname, 'w')
+        tmp_file.write(tmpstr)
+        tmp_file.close()
+        print "Wrote {0}".format(fullpathname)
+        return fullpathname
+
+    def createUtilKS(self, tdl):
+        util_post = """
+%post
+# For cloud images, 'eth0' _is_ the predictable device name, since
+# we don't want to be tied to specific virtual (!) hardware
+rm -f /etc/udev/rules.d/70*
+ln -s /dev/null /etc/udev/rules.d/80-net-setup-link.rules
+
+# simple eth0 config, again not hard-coded to the build hardware
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+EOF
+%end
+"""
+        util_tdl = oz.TDL.TDL(open(tdl).read())
+        oz_class = oz.GuestFactory.guest_factory(util_tdl, None, None)
+        util_ksname = oz_class.get_auto_path()
+        util_ks = open(util_ksname).read()
+        util_ks = util_ks + util_post
+        util_ksfilename = os.path.join(self.workdir, os.path.basename(util_ksname.replace(".auto", ".ks")))
+
+        # Write out to tmp file in workdir
+        self.dumpTempMeta(util_ksfilename, util_ks)
+
+        return util_ks
+
+    def returnDockerFile(self):
+        docker_subs = {'DOCKER_OS': getattr(self, 'docker_os_name')}
+        docker_file = """
+FROM @DOCKER_OS@
+ADD lorax.repo /etc/yum.repos.d/
+ADD lorax.tmpl /root/
+ADD lorax.sh /root/
+RUN chmod u+x /root/lorax.sh
+RUN yum -y swap fakesystemd systemd
+RUN yum -y install ostree lorax
+RUN yum -y update
+
+CMD ["/bin/sh", "/root/lorax.sh"]
+        """
+
+        for subname, subval in docker_subs.iteritems():
+            docker_file = docker_file.replace('@%s@' % (subname, ), subval)
+
+        return docker_file, getattr(self, 'docker_os_name')
+
+    def createContainer(self, outputdir, post=None):
+        imgfunc = ImageFunctions()
+        repos = self.getrepos(self.jsonfilename)
+        self.dumpTempMeta(os.path.join(self.workdir, "lorax.repo"), repos)
+        lorax_tmpl = open(os.path.join(self.pkgdatadir, 'lorax-http-repo.tmpl')).read()
+        lorax_repos = []
         if self.lorax_additional_repos:
+            if getattr(self, 'yum_baseurl') not in self.lorax_additional_repos:
+                self.lorax_additional_repos += ", {0}".format(getattr(self, 'yum_baseurl'))
             for repourl in self.lorax_additional_repos.split(','):
-                lorax_opts.extend(['-s', repourl.strip()])
-        http_proxy = os.environ.get('http_proxy')
-        if http_proxy:
-            lorax_opts.extend([ '--proxy', http_proxy ])
+                lorax_repos.extend(['-s', repourl.strip()])
+        else:
+            lorax_repos.append('-s {0}'.format(getattr(self, 'yum_baseurl')))
+        port_file_path = self.workdir + '/repo-port'
+        subprocess.check_call(['ostree',
+                               'trivial-httpd', '--autoexit', '--daemonize',
+                               '--port-file', port_file_path],
+                              cwd=self.ostree_repo)
 
-        template_src = self.pkgdatadir + '/lorax-embed-repo.tmpl'
-        template_dest = self.workdir + '/lorax-embed-repo.tmpl'
-        shutil.copy(template_src, template_dest)
+        httpd_port = open(port_file_path).read().strip()
+        substitutions = {'OSTREE_PORT': httpd_port,
+                         'OSTREE_REF':  self.ref,
+                         'OSTREE_OSNAME':  self.os_name,
+                         'LORAX_REPOS': " ".join(lorax_repos),
+                         'OS_PRETTY': self.os_pretty_name,
+                         'OS_VER': self.release
+                         }
+        if '@OSTREE_HOSTIP@' in lorax_tmpl:
+            host_ip = "localhost"
+            substitutions['OSTREE_HOSTIP'] = host_ip
 
-        if post is not None:
-            # Yeah, this is pretty awful.
-            post_str = '%r' % ('%post --erroronfail\n' + open(post).read() + '\n%end\n', )
-            with open(template_dest, 'a') as f:
-                f.write('\nappend usr/share/anaconda/interactive-defaults.ks %s\n' % (post_str, ))
+        for subname, subval in substitutions.iteritems():
+            print subname
+            lorax_tmpl = lorax_tmpl.replace('@%s@' % (subname, ), subval)
 
-        lorax_workdir = os.path.join(self.workdir, 'lorax')
-        os.makedirs(lorax_workdir)
-        run_sync(['lorax', '--nomacboot',
-                  '--add-template=%s' % template_dest,
-                  '--add-template-var=ostree_osname=%s' % self.os_name,
-                  '--add-template-var=ostree_repo=%s' % self.ostree_repo,
-                  '--add-template-var=ostree_ref=%s' % self.ref,
-                  '-p', self.os_pretty_name, '-v', self.release,
-                  '-r', self.release, '-s', self.yum_baseurl,
-                  '-e', 'systemd-container',
-                  ] + lorax_opts + ['output'],
-                 cwd=lorax_workdir)
-        # We injected data into boot.iso, so it's now installer.iso
-        lorax_output = lorax_workdir + '/output'
-        lorax_images = lorax_output + '/images'
-        os.rename(lorax_images + '/boot.iso', lorax_images + '/installer.iso')
+        self.dumpTempMeta(os.path.join(self.workdir, "lorax.tmpl"), lorax_tmpl)
 
-        treeinfo = lorax_output + '/.treeinfo'
-        treeinfo_tmp = treeinfo + '.tmp'
-        with open(treeinfo) as treein:
-            with open(treeinfo_tmp, 'w') as treeout:
-                for line in treein:
-                    if line.startswith('boot.iso'):
-                        treeout.write(line.replace('boot.iso', 'installer.iso'))
-                    else:
-                        treeout.write(line)
-        os.rename(treeinfo_tmp, treeinfo)
+        os_v = getattr(self, 'release')
+        os_pretty_name = os_pretty_name = '"{0}"'.format(getattr(self, 'os_pretty_name'))
 
-        for p in os.listdir(lorax_output):
-            print "Generated: " + p
-            shutil.move(os.path.join(lorax_output, p),
-                        os.path.join(outputdir, p))
+        docker_file, docker_os = self.returnDockerFile()
 
-## End Composer
+        lorax_cmd = ['lorax', '--nomacboot', '--add-template=/root/lorax.tmpl', '-e', 'fakesystemd', '-e', 'systemd-container', '-p', os_pretty_name, '-v', os_v, '-r', os_v, " ".join(lorax_repos), '/out']
+
+        # There is currently a bug for loop devices in containers,
+        # so we make at least one device to be sure.
+        # https://groups.google.com/forum/#!msg/docker-user/JmHko2nstWQ/5iuzVf67vfEJ
+
+        lorax_shell = "mknod -m660 /dev/loop0 b 7 0 \n"
+        lorax_shell = lorax_shell + " ".join(lorax_cmd)
+        self.dumpTempMeta(os.path.join(self.workdir, "lorax.sh"), lorax_shell)
+
+        tmp_docker_file = self.dumpTempMeta(os.path.join(self.workdir, "Dockerfile"), docker_file)
+
+        # Docker build
+        db_cmd = ['docker', 'build', '-t', docker_os, os.path.dirname(tmp_docker_file)]
+        run_sync(db_cmd)
+
+        # Docker run
+        dr_cidfile = os.path.join(self.workdir, "containerid")
+        dr_cmd = ['docker', 'run', '-it', '--net=host', '--privileged=true', '--cidfile="' + dr_cidfile + '"', docker_os]
+        run_sync(dr_cmd)
+        cid = open(dr_cidfile).read().strip()
+
+        # Copy the files images out
+        dcp_cmd = ['docker', 'cp', cid + ":/out/images", outputdir]
+        print "Copied images to " + outputdir
+        run_sync(dcp_cmd)
+
+        # Cop lorax logs to tempspace
+        dock_logs = ['lorax.log', 'program.log', 'yum.log']
+        for log in dock_logs:
+            dcp_cmd = ['docker', 'cp', cid + ":/" + log, os.path.join(self.workdir)]
+            print "Copying {0} to {1}".format(log, os.path.join(self.workdir))
+            run_sync(dcp_cmd)
+
+        # Copy the log to the tmp
+        # Marshalling issues, doesnt work yet
+        # dlog_cmd = ['docker', 'logs', cid]
+        # docker_log = json.JSONEncoder(subprocess.check_output(dlog_cmd))
+        # self.dumpTempMeta(os.path.join(self.workdir, "docker.log"), docker_log)
+
+    def create(self, outputdir, post=None):
+        imgfunc = ImageFunctions()
+        repos = self.getrepos(self.jsonfilename)
+        util_xml = self.template_xml(repos, os.path.join(self.pkgdatadir, 'lorax-indirection-repo.tmpl'))
+        lorax_repos = []
+        if self.lorax_additional_repos:
+            if getattr(self, 'yum_baseurl') not in self.lorax_additional_repos:
+                self.lorax_additional_repos += ", {0}".format(getattr(self, 'yum_baseurl'))
+            for repourl in self.lorax_additional_repos.split(','):
+                lorax_repos.extend(['-s', repourl.strip()])
+        else:
+            lorax_repos.append('-s {0}'.format(getattr(self, 'yum_baseurl')))
+
+        port_file_path = self.workdir + '/repo-port'
+        subprocess.check_call(['ostree',
+                               'trivial-httpd', '--autoexit', '--daemonize',
+                               '--port-file', port_file_path],
+                              cwd=self.ostree_repo)
+
+        httpd_port = open(port_file_path).read().strip()
+        print "trivial httpd port=%s" % (httpd_port, )
+        substitutions = {'OSTREE_PORT': httpd_port,
+                         'OSTREE_REF':  self.ref,
+                         'OSTREE_OSNAME':  self.os_name,
+                         'LORAX_REPOS': " ".join(lorax_repos),
+                         'OS_PRETTY': self.os_pretty_name,
+                         'OS_VER': self.release
+                         }
+        if '@OSTREE_HOSTIP@' in util_xml:
+            host_ip = getDefaultIP()
+            substitutions['OSTREE_HOSTIP'] = host_ip
+
+        print type(util_xml)
+        for subname, subval in substitutions.iteritems():
+            util_xml = util_xml.replace('@%s@' % (subname, ), subval)
+
+        # Dump util_xml to workdir for logging
+        self.dumpTempMeta(os.path.join(self.workdir, "lorax.xml"), util_xml)
+        global verbosemode
+        imgfacbuild = ImgFacBuilder(verbosemode=verbosemode)
+        imgfacbuild.verbosemode = verbosemode
+        imgfunc.checkoz()
+        util_ks = self.createUtilKS(self.tdl)
+
+        # Building of utility image
+        parameters = {"install_script": util_ks,
+                      "generate_icicle": False,
+                      "oz_overrides": json.dumps(imgfunc.ozoverrides)
+                      }
+        print "Starting build"
+        if self.util_uuid is None:
+            util_image = imgfacbuild.build(template=open(self.util_tdl).read(), parameters=parameters)
+            print "Created Utility Image: {0}".format(util_image.data)
+
+        else:
+            pim = PersistentImageManager.default_manager()
+            util_image = pim.image_with_id(self.util_uuid)
+            print "Re-using Utility Image: {0}".format(util_image.identifier)
+
+        # Now lorax
+        bd = BuildDispatcher()
+        lorax_parameters = {"results_location": "/lorout/output.tar",
+                            "utility_image": util_image.identifier,
+                            "utility_customizations": util_xml,
+                            "oz_overrides": json.dumps(imgfunc.ozoverrides)
+                            }
+        print "Building the lorax image"
+        loraxiso_builder = bd.builder_for_target_image("indirection", image_id=util_image.identifier, template=None, parameters=lorax_parameters)
+        loraxiso_image = loraxiso_builder.target_image
+        thread = loraxiso_builder.target_thread
+        thread.join()
+
+        # Extract the tarball of built images
+        print "Extracting images to {0}/images".format(outputdir)
+        t = tarfile.open(loraxiso_image.data)
+        t.extractall(path=outputdir)
+
+# End Composer
+
 
 def main(cmd):
     parser = argparse.ArgumentParser(description='Create an installer image',
                                      parents=[TaskBase.baseargs()])
     parser.add_argument('-b', '--yum_baseurl', type=str, required=False, help='Full URL for the yum repository')
     parser.add_argument('-p', '--profile', type=str, default='DEFAULT', help='Profile to compose (references a stanza in the config file)')
+    parser.add_argument('--util_uuid', required=False, default=None, type=str, help='The UUID of an existing utility image')
+    parser.add_argument('--util_tdl', required=False, default=None, type=str, help='The TDL for the utility image')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
+    parser.add_argument('--virt', action='store_true', help='Use libvirt')
     parser.add_argument('--post', type=str, help='Run this %%post script in interactive installs')
     parser.add_argument('-o', '--outputdir', type=str, required=False, help='Path to image output directory')
     args = parser.parse_args()
     composer = InstallerTask(args, cmd, profile=args.profile)
     composer.show_config()
-
-    composer.create(outputdir=getattr(composer, 'outputdir'), post=args.post)
+    global verbosemode
+    verbosemode = args.verbose
+    if args.virt:
+        composer.create(outputdir=getattr(composer, 'outputdir'), post=args.post)
+    else:
+        composer.createContainer(outputdir=getattr(composer, 'outputdir'), post=args.post)
 
     composer.cleanup()

--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -33,7 +33,7 @@ class TaskBase(object):
               'os_name', 'os_pretty_name',
               'tree_name', 'tree_file', 'arch', 'release', 'ref',
               'yum_baseurl', 'lorax_additional_repos', 'local_overrides', 'http_proxy',
-              'selinux', 'configdir'
+              'selinux', 'configdir', 'docker_os_name'
             ]
 
 
@@ -98,7 +98,7 @@ class TaskBase(object):
                     fail_msg("No kickstart was passed with -k and {0} does not exist".format(getattr(self, 'kickstart')))
 
         # Set tdl from args, else fallback to default
-        if cmd == "imagefactory":
+        if cmd in ["imagefactory"] or ( cmd in ['installer'] and args.virt ):
             if 'tdl' in args and args.tdl is not None:
                 setattr(self, 'tdl', args.tdl)
             else:
@@ -117,6 +117,14 @@ class TaskBase(object):
         if cmd == "installer":
             if not self.yum_baseurl and args.yum_baseurl == None:
                 fail_msg("No yum_baseurl was provided in your config.ini or with installer -b.")
+
+            # Set util_uuid
+            self.util_uuid = args.util_uuid
+
+            if not args.util_uuid and not args.util_tdl and args.virt:
+                fail_msg ("You must provide a TDL for your utility image with --util_tdl")
+            else:
+                self.util_tdl = args.util_tdl
 
         if self.http_proxy:
             os.environ['http_proxy'] = self.http_proxy
@@ -144,7 +152,8 @@ class TaskBase(object):
             fail_msg("Section {0} is not defined in your config file ({1}). Valid sections/profiles are {2}".format(
                 profile, configfile, sections))
         config_req = ['ostree_repo', 'os_name', 'os_pretty_name', 'outputdir',
-                      'tree_name', 'tree_file', 'arch', 'release', 'ref', 'yum_baseurl']
+                      'tree_name', 'tree_file', 'arch', 'release', 'ref', 'yum_baseurl',
+                      'configdir', 'docker_os_name']
         missing_confs = []
         for req in config_req:
             if not settings.has_option(profile, req):


### PR DESCRIPTION
When using rpm-os-toolbox to create installer images (PXE and isos),
lorax and friends really want to run in the native operating system. So,
for example, creating a centos installer image on a Fedora system will
fail.  We now by default use a container to create the image.  You can also
pass --virt to use imagefactory and indirection.
- installer.py
  - createContainer() does the work for the container bits
  - createContainer requires docker_os_name which defines the container
    base OS.  Like fedora:rawhide or centos:latest
  - create uses indirection
  - subjected entire file to pep8 and flake corrections
- imagefactory.py
  - small changes to allow installer.py to reuse some of its classes
- taskbase.py
  - added docker_os_name to ATTRS
  - added parsing of util_uuid which allows to re-use and existing
    imagefactory utility image to cut down on processing time
- lorax-http-repo.tmpl
  - New file for using ostree httpd sync'ing
- lorax-indirection-repo.tmpl
  - New file for using imagefactory indirection to build installer images
- Makefile-toolbox.am
  - added installation of the lorax-http-repo.tmpl
  - added installation of the lorax-indirection-repo.tmpl
- rpm-ostree-toolbox.spec.in
  - Add requires for docker and IndirectionCloud
