### PR TITLE
installer images created via libvirt or container

### DIFF
--- a/Makefile-toolbox.am
+++ b/Makefile-toolbox.am
@@ -70,6 +70,8 @@ pytoolboxdatadir = $(pkgdatadir)
 pytoolboxdata_DATA = \
 	src/py/config.ini.sample \
 	src/py/lorax-embed-repo.tmpl \
+	src/py/lorax-http-repo.tmpl \
+	src/py/lorax-indirection-repo.tmpl \
 	$(NULL)
 
 pytoolboxpydir = $(pkglibdir)/py

--- a/packaging/rpm-ostree-toolbox.spec.in
+++ b/packaging/rpm-ostree-toolbox.spec.in
@@ -34,12 +34,20 @@ Requires: kernel
 
 Requires: rpm-ostree
 Requires: lorax
+
+%if 0%{?fedora}
+Requires: docker-io
+%else
+Requires: docker
+%endif
+
 # Imagefactory
 Requires: imagefactory >= 1.1.6-1
 Requires: imagefactory-plugins-TinMan >= 1.1.6-1
 Requires: imagefactory-plugins-OVA >= 1.1.6-1
 Requires: imagefactory-plugins-vSphere >= 1.1.6-1
 Requires: imagefactory-plugins-RHEVM >= 1.1.6-1
+Requires: imagefactory-plugins-IndirectionCloud >= 1.1.6-1
 
 %if 0%{?rhel}
 %else

--- a/src/py/lorax-http-repo.tmpl
+++ b/src/py/lorax-http-repo.tmpl
@@ -1,0 +1,11 @@
+<%page args='root'/>
+mkdir install/ostree
+runcmd ostree --repo=${root}/install/ostree init --mode=archive-z2
+runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-verify=false http://@OSTREE_HOSTIP@:@OSTREE_PORT@
+runcmd ostree --repo=${root}/install/ostree/ pull --mirror ostree-mirror @OSTREE_REF@
+
+
+append usr/share/anaconda/interactive-defaults.ks "ostreesetup --nogpg --osname=@OSTREE_OSNAME@ --remote=@OSTREE_OSNAME@ --url=file:///install/ostree --ref=@OSTREE_REF@\n"
+append usr/share/anaconda/interactive-defaults.ks "services --disabled cloud-init,cloud-config,cloud-final,cloud-init-local\n"
+append usr/share/anaconda/interactive-defaults.ks "%post --erroronfail\nrm -f /etc/ostree/remotes.d/@OSTREE_OSNAME@.conf\n%end\n"
+

--- a/src/py/lorax-indirection-repo.tmpl
+++ b/src/py/lorax-indirection-repo.tmpl
@@ -1,0 +1,24 @@
+<template>
+<files>
+<file name="/root/lorax.tmpl">
+&lt;%page args='root'/&gt;
+mkdir install/ostree
+runcmd ostree --repo=${root}/install/ostree init --mode=archive-z2
+runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-verify=false http://@OSTREE_HOSTIP@:@OSTREE_PORT@
+runcmd ostree --repo=${root}/install/ostree/ pull --mirror ostree-mirror @OSTREE_REF@
+
+
+append usr/share/anaconda/interactive-defaults.ks "ostreesetup --nogpg --osname=@OSTREE_OSNAME@ --remote=@OSTREE_OSNAME@ --url=file:///install/ostree --ref=@OSTREE_REF@\n"
+append usr/share/anaconda/interactive-defaults.ks "services --disabled cloud-init,cloud-config,cloud-final,cloud-init-local\n"
+append usr/share/anaconda/interactive-defaults.ks "%post --erroronfail\nrm -f /etc/ostree/remotes.d/@OSTREE_OSNAME@.conf\n%end\n"
+</file>
+</files>
+<commands>
+   <command name='mount'>mount /dev/vdb1 /mnt</command>
+   <command name="installlorax">yum install -y lorax ostree</command>
+   <command name="makedancry">setenforce 0</command>
+   <command name="lorax">lorax --nomacboot --add-template=/root/lorax.tmpl -p "@OS_PRETTY@" -v @OS_VER@ -r @OS_VER@ @LORAX_REPOS@ /mnt/lorout</command>
+   <command name="makeiancry">tar cvf /mnt/lorout/output.tar -C /mnt/lorout/ images</command>
+</commands>
+</template>
+

--- a/src/py/rpmostreecompose/imagefactory.py
+++ b/src/py/rpmostreecompose/imagefactory.py
@@ -81,8 +81,8 @@ class ImgFacBuilder(ImgBuilder):
         self.tlog = logging.getLogger()
         self.tlog.setLevel(logging.DEBUG)
         self.tlog.addHandler(self.fhandler)
- 
-        global verbosemode
+        verbosemode = kwargs.get('verbosemode', False)
+
         if verbosemode:
             ch = logging.StreamHandler(sys.stdout)
             ch.setLevel(logging.DEBUG)
@@ -235,7 +235,6 @@ class ImageFactoryTask(TaskBase):
             print outputname
 
             qemucmd = ['qemu-img', 'convert', '-f', 'qcow2', '-O', 'raw', image.data, outputname]
-            imageouttypes.pop(imageouttypes.index("raw"))
             subprocess.check_call(qemucmd)
             imageouttypes.pop(imageouttypes.index("raw"))
             print "Created: {0}".format(outputname)
@@ -255,7 +254,8 @@ class ImageFactoryTask(TaskBase):
     def builder(self):
         # TODO: option to switch to koji builder
         if True:
-            return ImgFacBuilder(workdir=self.workdir)
+            global verbosemode
+            return ImgFacBuilder(workdir=self.workdir, verbosemode=verbosemode)
         else:
             return KojiBuilder()
 

--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -33,7 +33,7 @@ class TaskBase(object):
               'os_name', 'os_pretty_name',
               'tree_name', 'tree_file', 'arch', 'release', 'ref',
               'yum_baseurl', 'lorax_additional_repos', 'local_overrides', 'http_proxy',
-              'selinux', 'configdir'
+              'selinux', 'configdir', 'docker_os_name'
             ]
 
 
@@ -98,7 +98,7 @@ class TaskBase(object):
                     fail_msg("No kickstart was passed with -k and {0} does not exist".format(getattr(self, 'kickstart')))
 
         # Set tdl from args, else fallback to default
-        if cmd == "imagefactory":
+        if cmd in ["imagefactory"] or ( cmd in ['installer'] and args.virt ):
             if 'tdl' in args and args.tdl is not None:
                 setattr(self, 'tdl', args.tdl)
             else:
@@ -117,6 +117,14 @@ class TaskBase(object):
         if cmd == "installer":
             if not self.yum_baseurl and args.yum_baseurl == None:
                 fail_msg("No yum_baseurl was provided in your config.ini or with installer -b.")
+
+            # Set util_uuid
+            self.util_uuid = args.util_uuid
+
+            if not args.util_uuid and not args.util_tdl and args.virt:
+                fail_msg ("You must provide a TDL for your utility image with --util_tdl")
+            else:
+                self.util_tdl = args.util_tdl
 
         if self.http_proxy:
             os.environ['http_proxy'] = self.http_proxy
@@ -144,7 +152,8 @@ class TaskBase(object):
             fail_msg("Section {0} is not defined in your config file ({1}). Valid sections/profiles are {2}".format(
                 profile, configfile, sections))
         config_req = ['ostree_repo', 'os_name', 'os_pretty_name', 'outputdir',
-                      'tree_name', 'tree_file', 'arch', 'release', 'ref', 'yum_baseurl']
+                      'tree_name', 'tree_file', 'arch', 'release', 'ref', 'yum_baseurl',
+                      'docker_os_name']
         missing_confs = []
         for req in config_req:
             if not settings.has_option(profile, req):


### PR DESCRIPTION
When using rpm-os-toolbox to create installer images (PXE and isos),
lorax and friends really want to run in the native operating system. So,
for example, creating a centos installer image on a Fedora system will
fail.  We now by default use a container to create the image.  You can also
pass --virt to use imagefactory and indirection.
- installer.py
  - createContainer() does the work for the container bits
  - createContainer requires docker_os_name which defines the container
    base OS.  Like fedora:rawhide or centos:latest
  - create uses indirection
  - subjected entire file to pep8 and flake corrections
- imagefactory.py
  - small changes to allow installer.py to reuse some of its classes
- taskbase.py
  - added docker_os_name to ATTRS
  - added parsing of util_uuid which allows to re-use and existing
    imagefactory utility image to cut down on processing time
- lorax-http-repo.tmpl
  - New file for using ostree httpd sync'ing
- lorax-indirection-repo.tmpl
  - New file for using imagefactory indirection to build installer images
- Makefile-toolbox.am
  - added installation of the lorax-http-repo.tmpl
  - added installation of the lorax-indirection-repo.tmpl
- rpm-ostree-toolbox.spec.in
  - Add requires for docker and IndirectionCloud
