### PR TITLE
Update README.md and sample.config.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,31 @@ rpm-ostree-toolbox
 ==================
 
 This is a higher level app on top of the core `rpm-ostree` tool.  It
-contains a variety of tools and scripts for making disk images, the
-"repoweb" generator, and such.
+contains a variety of tools and scripts for making disk images, installer images, and ostree trees.
 
-The "postprocess" command is still useful though as a way to avoid
-creating multiple disk images for different variants.
+The rpm-ostree-toolbox should be called with one of three subcommands:
 
-The "trivial-autobuilder" code is also being reworked into new scripts
-in fedora-atomic.
+* treecompose
+* imagefactory
+* installer
 
-Running an unattended compose
------------------------------
 
-Most likely, you want to start using rpm-ostree by running a "compose"
-server.  We use the term "compose" instead of "build" as there's no
-actual source code being changed here, just a mechanical
-transformation of RPM -> OSTree -> disk images.
+Getting started
+---------------
+Depending on the subcommand being called with rpm-ostree-toolbox, a number of different input files are required.  The main configuration file is generally called config.ini.  A sample is provided with rpm-ostree-toolbox.  Be sure to review and edit the config.ini where applicable.  It is heavily commented and self-explanatory.
 
-First, you need to run through the setup instructions of the current
-rpm-ostree README.md.
+There is a git repository to help you get started with rpm-ostree-toolbox and Fedora located at https://git.fedorahosted.org/cgit/fedora-atomic.git .
 
-Once you've done this, see `doc/autobuilder.json` for a sample JSON
-configuration file for the autobuilder.
 
-	$ rpm-ostree-toolbox trivial-autocompose /path/to/autobuilder.json
+rpm-ostree-toolbox treecompose
+------------------------------
+This allows you to create a tree of ostree content.  It takes various inputs from a JSON file to perform most of its actions.  When complete, you will have an ostree with content suitable for creating 
+
+rpm-ostree-toolbox imagefactory
+-------------------------------
+With imagefactory, you can create various virtualized images with libvirt related tooling.  Currently it is capable of making qcow2, raw, vsphere, and rhevm images.  This can be altered with the -i argument.  
+
+rpm-ostree-toolbox installer
+----------------------------
+This command creates ISO and PXE images that can be used as install media.  This can either be done with a container-based approach or using libvirt.
+

--- a/src/py/config.ini.sample
+++ b/src/py/config.ini.sample
@@ -1,26 +1,71 @@
 [DEFAULT]
 
+# Where output (treecomposes, isos, and qcows) will end up. Common
+# practice would be to set to something like: 
+# /srv/rpm-ostree/%(os_name)s/%(release)s
 outputdir   =
-# workdir     = os.getcwd()
-# srcdir      = os.path.join(os.path.dirname(sys.argv[0], '..')
+
+# Location for JSON files, Yum repo files, kickstart , and tdl files.  The
+# path needs to be *fully qualified*.
+config_dir  =
+
+# The name of the Docker image that should be used if the installer function is
+# called.
+docker_os_name = fedora:latest
+
+# Where tempfiles, logs, and such are stored during build.  If left blank,
+# this will default to /tmp
+# workdir     = 
+
+# Caching location for ostree trees.
 rpmostree_cache_dir = %(outputdir)s/cache
+
+# The location where of where the ostree repository
 ostree_repo = %(outputdir)s/repo
+
+# Name applied to the composed content
 os_name     = fedora-atomic
+
+# Same but pretty
 os_pretty_name = Fedora Atomic
+
+# The name to apply to a set of packages.
 tree_name   = docker-host
+
+# Reference to the tree file which controls much of the -toolbox
+# process.  It contains repos, package lists, and much more
 tree_file   = %(os_name)s-%(tree_name)s.json
+
+# Arch to be composed
 arch        = x86_64
+
+# The OS release to be used
 release     = rawhide
+
+# ostree uses refs to deal with content.  This defines the ref
+# name that will be used when composing.
 ref         = %(os_name)s/%(release)s/%(arch)s/%(tree_name)s
-# yum_baseurl = http://example.com/baserepo
-# Comma separated
+
+# yum_baseurl should point to the main location where yum can get its content. More
+# repos can be defined in .repo files in your configdir. An example could be:
+# http://download.fedoraproject.org/pub/fedora/linux/development/%(release)s/%(arch)s/os/
+yum_baseurl = 
+
+# Repositories above and beyond yum_baseurl that lorax can use to compose ISO content.
+# These need to be provides in a comma separated list.
 # lorax_additional_repos = http://example.com/baserepo, http://example.com/addrepo
+
 # local_overrides
+# Deprecated
 
 [rawhide]
 
 [fedora-21]
 release = 21
+
+
+# Everything below is applicable to configs being used in automated or structured builds
+# and is not needed for simple, one-off operations.
 
 # For authenticating to message bus. rpm-ostree-toolbox-kinit uses
 # these settings to write credentials into $KRB5CCNAME, which must


### PR DESCRIPTION
README.md
    \* Now contains a sub-command description for treecompose,
      imagefactory, and installer

sample.config.ini
    \* Heavily commented the sample file as well as added the new
      options (docker_os_name and configdir) that has been added
      recently.
