### PR TITLE
Add ability to define libvirt network

### DIFF
--- a/src/py/rpmostreecompose/installer.py
+++ b/src/py/rpmostreecompose/installer.py
@@ -289,6 +289,7 @@ def main(cmd):
     parser.add_argument('--util_tdl', required=False, default=None, type=str, help='The TDL for the utility image')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
     parser.add_argument('--skip-subtask', action='append', help='Skip a subtask (currently: docker-lorax)', default=[])
+    parser.add_argument('--virtnetwork', default=None, type=str, required=False, help='Optional name of libvirt network')
     parser.add_argument('--virt', action='store_true', help='Use libvirt')
     parser.add_argument('--post', type=str, help='Run this %%post script in interactive installs')
     parser.add_argument('-o', '--outputdir', type=str, required=True, help='Path to image output directory')

--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -82,6 +82,11 @@ class TaskBase(object):
         else:
             self.tree_file = os.path.join(self.configdir, self.tree_file)
 
+        # Look for virtnetwork
+
+        if 'virtnetwork' in args:
+            self.virtnetwork = args.virtnetwork
+
         # Set outputdir if overriden by command line
         if 'outputdir' in args and args.outputdir is not None:
             setattr(self, 'outputdir', args.outputdir)


### PR DESCRIPTION
This cleans up some of the logic around determining if the user has
a default libvirt network.  Previously, the code looked for a network
called 'default' and failed out prompting the user to edit a file. Now
we allow uses to pass --virtnetwork <some name from virsh net-list> if
they are in a non-standard setup.  Moreover, we now look to see how many
networks are defined and if only 1, we assume to use that one.  If
multiple networks exist, we look for the 'default' network and use that.

imagefactory:
    \* getDefaultIP now accepts a hostnet arguement from --virtnetwork
    \* Added conditionals to determine the default network

taskbase:
    \* added new variable virtnetwork for consumption by imagefactory
      and installer

installer:
    \* added --virtnetwork to command line args and pass to getDefaultIP
