### PR TITLE
timestamps: switch to UTC

### DIFF
--- a/src/scripts/rpm-ostree-toolbox-watch
+++ b/src/scripts/rpm-ostree-toolbox-watch
@@ -246,7 +246,7 @@ END_LOG_HEADER
     }
 
     print  "#\n";
-    printf "# %s BEGIN\n\n", localtime->datetime;
+    printf "# %sZ BEGIN\n\n", gmtime->datetime;
 
     # First: git pull. It's OK if this fails.
     # This should really be "git -C <dirname>" but git-1.8.3 (RHEL7) doesn't
@@ -278,9 +278,9 @@ END_LOG_HEADER
         }
     }
 
-    printf <<"END_LOG_TAIL", localtime->datetime, $msg;
+    printf <<"END_LOG_TAIL", gmtime->datetime, $msg;
 
-# %s FINISHED: %s
+# %sZ FINISHED: %s
 ###############################################################################
 END_LOG_TAIL
 
@@ -347,7 +347,7 @@ sub desired_systemd_units {
 #
 sub log_file {
     my $cwd = cwd();
-    my $t   = localtime;                # FIXME: gmtime instead?
+    my $t   = gmtime;
 
     # eg /srv/mybranch/tasks/treecompose/2014/11/03/05h2501
     my $dir = sprintf("%s/%s/%d/%02d/%02d/%02dh%02d%02d",

--- a/t/src/scripts/rpm-ostree-toolbox-watch/70-start_job.t
+++ b/t/src/scripts/rpm-ostree-toolbox-watch/70-start_job.t
@@ -90,7 +90,7 @@ my $expected_log = <<'EXPECTED_LOG_RE';
 #    _PID          = 123
 #    _SYSTEMD_UNIT = rpm-ostree-toolbox-git-monitor.service
 #
-# \d+-\d+-\d+T\d+:\d+:\d+ BEGIN
+# \d+-\d+-\d+T\d+:\d+:\d+Z BEGIN
 
 \$ \(cd \S+/atomic && git pull -r\)
 BEGIN \S+/bin/git
@@ -105,7 +105,7 @@ BEGIN \S+/bin/rpm-ostree-toolbox
   ./config.ini
 END   \S+/bin/rpm-ostree-toolbox
 
-# \d+-\d+-\d+T\d+:\d+:\d+ FINISHED: success
+# \d+-\d+-\d+T\d+:\d+:\d+Z FINISHED: success
 ####+
 EXPECTED_LOG_RE
 


### PR DESCRIPTION
It was stupid of me to use localtime. Let's correct that. This
makes us consistent with ostree timestamps. It's also saner
in general.
