### PR TITLE
rpm-ostree-toolbox.spec.in: Add new version dependancies

### DIFF
--- a/packaging/rpm-ostree-toolbox.spec.in
+++ b/packaging/rpm-ostree-toolbox.spec.in
@@ -42,12 +42,14 @@ Requires: docker
 %endif
 
 # Imagefactory
-Requires: imagefactory >= 1.1.6-1
-Requires: imagefactory-plugins-TinMan >= 1.1.6-1
-Requires: imagefactory-plugins-OVA >= 1.1.6-1
-Requires: imagefactory-plugins-vSphere >= 1.1.6-1
-Requires: imagefactory-plugins-RHEVM >= 1.1.6-1
-Requires: imagefactory-plugins-IndirectionCloud >= 1.1.6-1
+Requires: imagefactory >= 1.1.7-1
+Requires: imagefactory-plugins-TinMan >= 1.1.7-1
+Requires: imagefactory-plugins-OVA >= 1.1.7-1
+Requires: imagefactory-plugins-vSphere >= 1.1.7-1
+Requires: imagefactory-plugins-RHEVM >= 1.1.7-1
+Requires: imagefactory-plugins-IndirectionCloud >= 1.1.7-1
+
+Requires: VMDKstream >= 0.3-1
 
 %if 0%{?rhel}
 %else


### PR DESCRIPTION
The addition of vagrant images requires imagefactory-1.1.7 and
VMDKstream-0.3-1 as minimums.