### PR TITLE
Add ability to inject OSTrees by URL

### DIFF
--- a/src/py/lorax-http-repo.tmpl
+++ b/src/py/lorax-http-repo.tmpl
@@ -1,7 +1,7 @@
 <%page args='root'/>
 mkdir install/ostree
 runcmd ostree --repo=${root}/install/ostree init --mode=archive-z2
-runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-verify=false http://127.0.0.1:@OSTREE_PORT@
+runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-verify=false http://@OSTREE_HOST@:@OSTREE_PORT@/@OSTREE_PATH@
 runcmd ostree --repo=${root}/install/ostree/ pull --mirror ostree-mirror @OSTREE_REF@
 
 

--- a/src/py/lorax-indirection-repo.tmpl
+++ b/src/py/lorax-indirection-repo.tmpl
@@ -4,7 +4,7 @@
 &lt;%page args='root'/&gt;
 mkdir install/ostree
 runcmd ostree --repo=${root}/install/ostree init --mode=archive-z2
-runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-verify=false http://@OSTREE_HOSTIP@:@OSTREE_PORT@
+runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-verify=false http://@OSTREE_HOSTIP@:@OSTREE_PORT@/@OSTREE_PATH@
 runcmd ostree --repo=${root}/install/ostree/ pull --mirror ostree-mirror @OSTREE_REF@
 
 

--- a/src/py/rpmostreecompose/installer.py
+++ b/src/py/rpmostreecompose/installer.py
@@ -23,6 +23,7 @@ import subprocess
 import oz.TDL
 import oz.GuestFactory
 import tarfile
+import shutil
 
 from .taskbase import TaskBase
 from .utils import fail_msg, run_sync, TrivialHTTP
@@ -128,7 +129,7 @@ for x in $(seq 0 6); do
   path=/dev/loop${{x}}
   if ! test -b ${{path}}; then mknod -m660 ${{path}} b 7 ${{x}}; fi
 done
-sed -e "s,@OSTREE_PORT@,${{OSTREE_PORT}}," < /root/lorax.tmpl.in > /root/lorax.tmpl
+sed -e "s,@OSTREE_PORT@,${{OSTREE_PORT}}," -e "s,@OSTREE_PATH@,${{OSTREE_PATH}}," -e "s,@OSTREE_HOST@,${{OSTREE_HOST}},"  < /root/lorax.tmpl.in > /root/lorax.tmpl
 echo Running: {0}
 exec {0}
 """.format(" ".join(map(GLib.shell_quote, lorax_cmd)))
@@ -168,13 +169,16 @@ CMD ["/bin/sh", "/root/lorax.sh"]
         lorax_tmpl = open(os.path.join(self.pkgdatadir, 'lorax-http-repo.tmpl')).read()
         port_file_path = self.workdir + '/repo-port'
 
-        # Start trivial-httpd
-
-        trivhttp = TrivialHTTP()
-        trivhttp.start(self.ostree_repo)
-        httpd_port = str(trivhttp.http_port)
-        print "trivial httpd serving %s on port=%s, pid=%s" % (self.ostree_repo, httpd_port, trivhttp.http_pid)
-
+        if not self.ostree_repo_is_remote:
+            # Start trivial-httpd
+            trivhttp = TrivialHTTP()
+            trivhttp.start(self.ostree_repo)
+            httpd_port = str(trivhttp.http_port)
+            httpd_url = '127.0.0.1'
+            print "trivial httpd serving %s on port=%s, pid=%s" % (self.ostree_repo, httpd_port, trivhttp.http_pid)
+        else:
+            httpd_port = self.httpd_port
+            httpd_url = self.httpd_host
         substitutions = {'OSTREE_REF':  self.ref,
                          'OSTREE_OSNAME':  self.os_name,
                          'OS_PRETTY': self.os_pretty_name,
@@ -188,19 +192,11 @@ CMD ["/bin/sh", "/root/lorax.sh"]
         self.dumpTempMeta(os.path.join(self.workdir, "lorax.tmpl"), lorax_tmpl)
 
         os_pretty_name = os_pretty_name = '"{0}"'.format(getattr(self, 'os_pretty_name'))
-
         docker_image_name = '{0}/rpmostree-toolbox-lorax'.format(getattr(self, 'docker_os_name'))
         if not ('docker-lorax' in self.args.skip_subtask):
             self._buildDockerImage(docker_image_name)
         else:
             print "Skipping subtask docker-lorax"
-
-        # Start trivial-httpd
-
-        trivhttp = TrivialHTTP()
-        trivhttp.start(self.ostree_repo)
-        httpd_port = str(trivhttp.http_port)
-        print "trivial httpd serving %s on port=%s, pid=%s" % (self.ostree_repo, httpd_port, trivhttp.http_pid)
 
         installer_outputdir = os.path.abspath(installer_outputdir)
 
@@ -208,11 +204,16 @@ CMD ["/bin/sh", "/root/lorax.sh"]
         dr_cidfile = os.path.join(self.workdir, "containerid")
 
         dr_cmd = ['docker', 'run', '-e', 'OSTREE_PORT={0}'.format(httpd_port),
-                  '--workdir', '/out', '--rm', '-it', '--net=host', '--privileged=true',
+                  '-e', 'OSTREE_HOST={0}'.format(httpd_url),
+                  '-e', 'OSTREE_PATH={0}'.format(self.httpd_path),
+                  '--workdir', '/out', '-it', '--net=host', '--privileged=true',
                   '-v', '{0}:{1}'.format(installer_outputdir, '/out'),
                   docker_image_name]
+
         run_sync(dr_cmd)
-        trivhttp.stop()
+
+        if not self.ostree_repo_is_remote:
+            trivhttp.stop()
 
         # We injected data into boot.iso, so it's now installer.iso
         lorax_output = installer_outputdir + '/lorax'
@@ -245,12 +246,14 @@ CMD ["/bin/sh", "/root/lorax.sh"]
 
         port_file_path = self.workdir + '/repo-port'
 
-        # Start trivial-httpd
-
-        trivhttp = TrivialHTTP()
-        trivhttp.start(self.ostree_repo)
-        httpd_port = str(trivhttp.http_port)
-        print "trivial httpd port=%s, pid=%s" % (httpd_port, trivhttp.http_pid)
+        if not self.ostree_repo_is_remote: 
+            # Start trivial-httpd
+            trivhttp = TrivialHTTP()
+            trivhttp.start(self.ostree_repo)
+            httpd_port = str(trivhttp.http_port)
+            print "trivial httpd port=%s, pid=%s" % (httpd_port, trivhttp.http_pid)
+        else:
+            httpd_port = str(self.httpd_port)
         substitutions = {'OSTREE_PORT': httpd_port,
                          'OSTREE_REF':  self.ref,
                          'OSTREE_OSNAME':  self.os_name,
@@ -259,8 +262,14 @@ CMD ["/bin/sh", "/root/lorax.sh"]
                          'OS_VER': self.release
                          }
         if '@OSTREE_HOSTIP@' in util_xml:
-            host_ip = getDefaultIP()
+            if not self.ostree_repo_is_remote:
+                host_ip = getDefaultIP()
+            else:
+                host_ip = self.httpd_host
             substitutions['OSTREE_HOSTIP'] = host_ip
+
+        if '@OSTREE_PATH' in util_xml:
+            substitutions['OSTREE_PATH'] = self.httpd_path
 
         print type(util_xml)
         for subname, subval in substitutions.iteritems():
@@ -306,7 +315,8 @@ CMD ["/bin/sh", "/root/lorax.sh"]
         print "Extracting images to {0}/images".format(installer_outputdir)
         t = tarfile.open(loraxiso_image.data)
         t.extractall(path=installer_outputdir)
-        trivhttp.stop()
+        if not self.ostree_repo_is_remote:
+            trivhttp.stop()
 
 # End Composer
 
@@ -343,7 +353,7 @@ def main(cmd):
         fail_msg("The output directory {0} does not exist".format(installer_outputdir))
         
     if args.virt:
-        composer.create(installer_ouputdir, post=args.post)
+        composer.create(installer_outputdir, post=args.post)
     else:
         composer.createContainer(installer_outputdir, post=args.post)
 


### PR DESCRIPTION
This patch allows you to pass an ostree by URL to the
imagefactory and installer subcommands.  You can now pass
these repos like:

    --ostreerepo http://<host/ip>:<port>/<path>

-toolbox will then verify that the remote repository in fact
contains the ref you want.