### PR TITLE
liveimage: Remove temporary disk image when complete

### DIFF
--- a/src/py/rpmostreecompose/liveimage.py
+++ b/src/py/rpmostreecompose/liveimage.py
@@ -136,6 +136,8 @@ CMD ["/bin/sh", "/root/lmc_shell.sh"]
         # Make readable for users
         os.chmod(finaldir, 0755)
 
+        # Remove temporary image
+        os.remove(os.path.join(lmc_outputdir, "lmc_input_disk"))
         print "Your images can be found at {0}".format(finaldir)
 
 


### PR DESCRIPTION
This patch removes the temporary disk image that is copied
for processing within the container where lvm runs.  Because
it is a copy, it can be deleted which saves about 1G of disk
space for end-users.