### PR TITLE
taskbase.py: Fix error when creating a repo on existing dir

### DIFF
--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -332,7 +332,12 @@ class TaskBase(object):
                                    "--repo="+self.ostree_repo, '--mode=archive-z2'])
         if self._repo is None:
             self._repo = OSTree.Repo(path=Gio.File.new_for_path(self.ostree_repo))
-            self._repo.open(None)
+
+            try:
+                self._repo.open(None)
+            except:
+                fail_msg("The repo location {0} has not been initialized.  Use 'ostree --repo={0} init --mode=archive-z2' to initialize and re-run rpm-ostree-toolbox".format(self.ostree_repo))
+
         return self._repo
 
     def show_config(self):


### PR DESCRIPTION
This patch catches a traceback when users try to create
an ostree repository on an existing directory location
but the location has not been initialized.  Using a
try/exception, we now "catch" the error and display a
user-friendly command to initialize the desired location.

This fixes:
    https://github.com/projectatomic/rpm-ostree-toolbox/issues/59