### PR TITLE
s/print/log() and delete a lot of debugging prints

### DIFF
--- a/src/py/rpmostreecompose/liveimage.py
+++ b/src/py/rpmostreecompose/liveimage.py
@@ -21,7 +21,7 @@ import os
 import shutil
 
 from .taskbase import TaskBase
-from .utils import fail_msg, run_sync
+from .utils import fail_msg, run_sync, log
 from .imagefactory import AbstractImageFactoryTask
 from .imagefactory import ImgFacBuilder
 from .installer import InstallerTask
@@ -37,11 +37,11 @@ class CreateLiveTask(AbstractImageFactoryTask):
         self._tdl = getattr(self, 'tdl')
 
     def createLiveDisk(self):
-        print "Starting build"
+        log("Starting build")
 
         if self._args.diskimage:
             self._inputdiskpath = self._args.diskimage
-            print "Using existing disk image: {0}".format(self._args.diskimage)
+            log("Using existing disk image: {0}".format(self._args.diskimage))
         else:
             self.checkoz("raw")
             imgfacbuild = ImgFacBuilder()
@@ -53,7 +53,7 @@ class CreateLiveTask(AbstractImageFactoryTask):
                         }
             image = imgfacbuild.build(template=open(self._tdl).read(), parameters=parameters)
             self._inputdiskpath = image.data
-            print "Created input disk: {0}".format(image.data)
+            log("Created input disk: {0}".format(image.data))
 
         self.lmcContainer(self._inputdiskpath)
 
@@ -138,7 +138,7 @@ CMD ["/bin/sh", "/root/lmc_shell.sh"]
 
         # Remove temporary image
         os.remove(os.path.join(lmc_outputdir, "lmc_input_disk"))
-        print "Your images can be found at {0}".format(finaldir)
+        log("Your images can be found at {0}".format(finaldir))
 
 
 # End liveimage

--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -27,7 +27,7 @@ import distutils.spawn
 from gi.repository import Gio, OSTree, GLib
 import iniparse
 import ConfigParser  # for errors
-from .utils import fail_msg
+from .utils import fail_msg, log
 import urlparse
 import urllib2
 from gi.repository import GLib
@@ -89,7 +89,6 @@ class TaskBase(object):
 
         for attr in self.ATTRS:
             val = self.getConfigValue(attr, settings, profile, defValue=defaults.get(attr))
-            print (attr, val)
             setattr(self, attr, val)
 
         self.ref = getattr(self, 'ref')
@@ -336,7 +335,7 @@ class TaskBase(object):
         return self._repo
 
     def show_config(self):
-        print "\n".join([ "%s=%s" % (x, str(getattr(self, x))) for x in self.ATTRS ])
+        log("\n".join([ "%s=%s" % (x, str(getattr(self, x))) for x in self.ATTRS ]))
 
     def cleanup(self):
         if self.workdir_is_tmp:

--- a/src/py/rpmostreecompose/treecompose.py
+++ b/src/py/rpmostreecompose/treecompose.py
@@ -28,7 +28,7 @@ from gi.repository import Gio, OSTree, GLib
 import iniparse
 
 from .taskbase import TaskBase
-from .utils import run_sync, fail_msg
+from .utils import run_sync, fail_msg, log
 
 
 def _rev2version(repo, rev):
@@ -125,7 +125,7 @@ class Treecompose(TaskBase):
                     pass
                 elif int(tv[3]) < lv[3]:
                     fail_msg("<cve> of version is getting older.")
-            print "** Building Version:", self.tree_version
+            log("** Building Version:", self.tree_version)
             rpmostreecmd.append('--add-metadata-string=version=' + self.tree_version)
 
         rpmostreecachedir = self.rpmostree_cache_dir
@@ -155,8 +155,8 @@ def main(cmd):
     origrev, newrev = composer.compose_tree()
 
     if origrev != newrev:
-        print "%s => %s" % (composer.ref, newrev)
+        log("%s => %s" % (composer.ref, newrev))
     else:
-        print "%s is unchanged at %s" % (composer.ref, origrev)
+        log("%s is unchanged at %s" % (composer.ref, origrev))
 
     composer.cleanup()

--- a/src/py/rpmostreecompose/utils.py
+++ b/src/py/rpmostreecompose/utils.py
@@ -31,9 +31,14 @@ def fail_msg(msg):
 
 def run_sync(args, **kwargs):
     """Wraps subprocess.check_call(), logging the command line too."""
-    print "Running: %s" % (subprocess.list2cmdline(args), )
+    log("Running: %s" % (subprocess.list2cmdline(args), ))
     subprocess.check_call(args, **kwargs)
 
+def log(msg):
+    "Print to standard output and flush it"
+    sys.stdout.write(msg)
+    sys.stdout.write('\n')
+    sys.stdout.flush()
 
 class TrivialHTTP():
     """ This class is used to control ostree's trivial-httpd which is used


### PR DESCRIPTION
I am hitting an error with a compose.  It is greatly obscured by the
fact that when piping output to a log file, because stdout is
buffered, you'll only see it at the end.

Fix this by introducing a log() function that flushes stdout.

Also delete a lot of debugging prints.

We still need to be even less verbose than this, but this patch takes
us closer.