### PR TITLE
treecompose: Also copy the passwd/group files

### DIFF
--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -317,7 +317,11 @@ class TaskBase(object):
         post_script = params.get('postprocess-script')
         if post_script is not None:
             shutil.copy2(os.path.join(treefile_base, post_script), self.workdir)
-            
+        for key in ['check-passwd', 'check-groups']:
+            check = params.get(key)
+            if check and check['type'] == 'file':
+                filename = check['filename']
+                shutil.copy2(os.path.join(treefile_base, filename), self.workdir)
 
     @property
     def repo(self):


### PR DESCRIPTION
Honestly we need to either stop generating the treefile, or add
first-class support in rpm-ostree for this.