### PR TITLE
-watch: Add a treecompose.post.d hook

### DIFF
--- a/src/scripts/rpm-ostree-toolbox-watch
+++ b/src/scripts/rpm-ostree-toolbox-watch
@@ -278,6 +278,12 @@ END_LOG_HEADER
         }
     }
 
+    my $postdir = '/etc/rpm-ostree-toolbox/treecompose.post.d';
+    if (-d $postdir) {
+	my @args = ("run-parts", $postdir);
+	system(@args) == 0 || print "warning: run-parts $postdir exited: $!" ;
+    }
+
     printf <<"END_LOG_TAIL", gmtime->datetime, $msg;
 
 # %sZ FINISHED: %s


### PR DESCRIPTION
So integrators can use this as a place to emit messages.