### PR TITLE
Verify validity ostree repos

### DIFF
--- a/src/py/lorax-http-repo.tmpl
+++ b/src/py/lorax-http-repo.tmpl
@@ -1,7 +1,7 @@
 <%page args='root'/>
 mkdir install/ostree
 runcmd ostree --repo=${root}/install/ostree init --mode=archive-z2
-runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-verify=false http://@OSTREE_HOST@:@OSTREE_PORT@/@OSTREE_PATH@
+runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-verify=false @OSTREE_URL@
 runcmd ostree --repo=${root}/install/ostree/ pull --mirror ostree-mirror @OSTREE_REF@
 
 

--- a/src/py/rpmostreecompose/installer.py
+++ b/src/py/rpmostreecompose/installer.py
@@ -27,7 +27,7 @@ import tarfile
 import shutil
 
 from .taskbase import ImageTaskBase
-from .utils import fail_msg, run_sync, TrivialHTTP, log
+from .utils import fail_msg, run_sync, TrivialHTTP, log, checkOSTree
 from .imagefactory import AbstractImageFactoryTask
 from .imagefactory import ImgFacBuilder
 from imgfac.BuildDispatcher import BuildDispatcher
@@ -91,7 +91,7 @@ for x in $(seq 0 6); do
   path=/dev/loop${{x}}
   if ! test -b ${{path}}; then mknod -m660 ${{path}} b 7 ${{x}}; fi
 done
-sed -e "s,@OSTREE_PORT@,${{OSTREE_PORT}}," -e "s,@OSTREE_PATH@,${{OSTREE_PATH}}," -e "s,@OSTREE_HOST@,${{OSTREE_HOST}},"  < /root/lorax.tmpl.in > /root/lorax.tmpl
+sed -e "s,@OSTREE_URL@,${{OSTREE_URL}},"  < /root/lorax.tmpl.in > /root/lorax.tmpl
 echo Running: {0}
 exec {0}
 """.format(" ".join(map(GLib.shell_quote, lorax_cmd)))
@@ -135,19 +135,24 @@ CMD ["/bin/sh", "/root/lorax.sh"]
             httpd_port = str(trivhttp.http_port)
             httpd_url = '127.0.0.1'
             log("trivial httpd serving %s on port=%s, pid=%s" % (self.ostree_repo, httpd_port, trivhttp.http_pid))
+            ostree_url = "http://{0}:{1}".format(httpd_url, httpd_port)
         else:
             httpd_port = self.httpd_port
             httpd_url = self.httpd_host
+            ostree_url = self.ostree_repo
+
+        # Test connectivity to the the ostree repository.  Here we look for
+        # for the repository's /config file.
+        if not checkOSTree(ostree_url):
+            fail_msg("Unable to verify find {0}/config and verify it as an ostree repository.  Please check your repository and re-run".format(ostree_url))
+
         substitutions = {'OSTREE_REF':  self.ref,
                          'OSTREE_OSNAME':  self.os_name,
                          'OS_PRETTY': self.os_pretty_name,
-                         'OS_VER': self.release
+                         'OS_VER': self.release,
+                         'OS_VER': self.release,
+                         'OSTREE_URL': ostree_url
                          }
-
-        # Test connectivity to trivial-httpd before we do the full run
-        # I'm seeing some issues where it fails sometimes, and this will help
-        # speed up debugging.
-        run_sync(['curl', 'http://' + httpd_url + ':' + httpd_port])
 
         for subname, subval in substitutions.iteritems():
             lorax_tmpl = lorax_tmpl.replace('@%s@' % (subname, ), subval)
@@ -164,12 +169,8 @@ CMD ["/bin/sh", "/root/lorax.sh"]
         # Docker run
         dr_cidfile = os.path.join(self.workdir, "containerid")
 
-        dr_cmd = ['docker', 'run', '--rm', '-e', 'OSTREE_PORT={0}'.format(httpd_port),
-                  '-e', 'OSTREE_HOST={0}'.format(httpd_url),
-                  '-e', 'OSTREE_PATH={0}'.format(self.httpd_path),
-                  '--workdir', '/out', '-it', '--net=host', '--privileged=true',
-                  '-v', '{0}:{1}'.format(self.image_workdir, '/out'),
-                  docker_image_name]
+        dr_cmd = ['docker', 'run', '--workdir', '/out', '-it', '--net=host', '--privileged=true',
+                  '-v', '{0}:{1}'.format(self.image_workdir, '/out'), docker_image_name]
 
         child_env = dict(os.environ)
         if 'http_proxy' in child_env:

--- a/src/py/rpmostreecompose/utils.py
+++ b/src/py/rpmostreecompose/utils.py
@@ -22,6 +22,7 @@ import subprocess
 import os
 import signal
 import ctypes
+import urllib2
 
 def fail_msg(msg):
     if False:
@@ -39,6 +40,15 @@ def log(msg):
     sys.stdout.write(msg)
     sys.stdout.write('\n')
     sys.stdout.flush()
+
+def checkOSTree(url):
+    url = url + "/config"
+    try:
+        f = urllib2.urlopen(url)
+    except:
+        return False
+
+    return True
 
 class TrivialHTTP(object):
     """ This class is used to control ostree's trivial-httpd which is used


### PR DESCRIPTION
We now check the validity of the provided --ostreerepo early in
the installer and imagefactory process.  This ensures that any
bad repositories are caught very early in the process.  This is
done by checking for the /config file in the ostree repo.