### PR TITLE
Pass truncated isolabel with --volid if product name is too long (#11…

### DIFF
--- a/src/py/rpmostreecompose/installer.py
+++ b/src/py/rpmostreecompose/installer.py
@@ -65,6 +65,11 @@ class InstallerTask(ImageTaskBase):
         os_v = self.release
         lorax_cmd = ['lorax', '--nomacboot', '--add-template=/root/lorax.tmpl', '-e', 'fakesystemd', '-e', 'systemd-container',
                      '-p', self.os_pretty_name, '-v', os_v, '-r', os_v]
+        isolabel = "{0}-{1}-{2}".format(self.os_pretty_name, os_v, self.arch)
+        if len(isolabel) > 32:
+            isolabel = isolabel[:32].strip()
+            log("Using isolabel truncated to 32 chars: %s" % isolabel)
+            lorax_cmd.extend(['--volid', isolabel])
         http_proxy = os.environ.get('http_proxy')
         if http_proxy:
             lorax_cmd.extend(['--proxy', http_proxy])


### PR DESCRIPTION
…93268)

This is required ie when we use
"Red Hat Enterprise Linux Atomic Host"
product name.

Related: rhbz#1193268