### PR TITLE
installer: Only remove origin config if it's file:///install/ostree

### DIFF
--- a/src/py/lorax-http-repo.tmpl
+++ b/src/py/lorax-http-repo.tmpl
@@ -7,5 +7,5 @@ runcmd ostree --repo=${root}/install/ostree/ pull --mirror ostree-mirror @OSTREE
 
 append usr/share/anaconda/interactive-defaults.ks "ostreesetup --nogpg --osname=@OSTREE_OSNAME@ --remote=@OSTREE_OSNAME@ --url=file:///install/ostree --ref=@OSTREE_REF@\n"
 append usr/share/anaconda/interactive-defaults.ks "services --disabled cloud-init,cloud-config,cloud-final,cloud-init-local\n"
-append usr/share/anaconda/interactive-defaults.ks "%post --erroronfail\nrm -f /etc/ostree/remotes.d/@OSTREE_OSNAME@.conf\n%end\n"
+append usr/share/anaconda/interactive-defaults.ks "%post --erroronfail\nfn=/etc/ostree/remotes.d/@OSTREE_OSNAME@.conf; if test -f "<%text>${fn}</%text>" && grep -q -e '^url=file:///install/ostree' "<%text>${fn}</%text>"$; then rm "<%text>${fn}</%text>"; fi\n%end\n"
 


### PR DESCRIPTION
For interactive installs from `installer.iso`, we pull content from
`file:///install/ostree`.  However, it's not really useful for that to
be the origin, so we were removing it in `%post`.

But doing so breaks for the case where we have
https://github.com/rhinstaller/anaconda/commit/438e19b8fe0f9f8d87a1a003f634d455973c87e1
(Fedora 21+, soon to be CentOS) *and* we are including a remote config
in the tree content (CentOS).

Let's be more conservative here and only delete the remote if it's
from `file:///install/ostree`.

Note that apparently the <%text>$$</%text> thing is how one needs to
do escaping in Mako.