### PR TITLE
[merged] allow screenshots generated by oz to be stored in alternate location …

### DIFF
--- a/src/py/rpmostreecompose/imagefactory.py
+++ b/src/py/rpmostreecompose/imagefactory.py
@@ -198,6 +198,11 @@ class AbstractImageFactoryTask(ImageTaskBase):
 
         self.ozoverrides = {}
 
+        # Screenshot_dir
+        if 'screenshot_dir' in self.args and self.args.screenshot_dir is not None:
+            self.addozoverride("paths", "screenshot_dir", self.args.screenshot_dir)
+
+
     def _ensure_httpd(self):
         """If we're using a local (on disk) OSTree repository, start a
         temporary http server for it.
@@ -548,6 +553,7 @@ def main(cmd):
     parser.add_argument('-k', '--kickstart', type=str, required=False, default=None, help='Path to kickstart') 
     parser.add_argument('--vkickstart', type=str, required=False, help='Path to vagrant kickstart') 
     parser.add_argument('-p', '--profile', type=str, default='DEFAULT', help='Profile to compose (references a stanza in the config file)')
+    parser.add_argument('-s', '--screenshot_dir', type=str, required=False, help='Directory to store screenshots of failed installs')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
     args = parser.parse_args()
      

--- a/src/py/rpmostreecompose/liveimage.py
+++ b/src/py/rpmostreecompose/liveimage.py
@@ -163,6 +163,7 @@ def main(cmd):
     parser.add_argument('--diskimage', type=str, required=False, help='Path to and including existing RAW disk image')
     parser.add_argument('--skip-subtask', action='append', help='Skip a subtask (currently: docker-create)', default=[])
     parser.add_argument('-b', '--yum_baseurl', type=str, required=False, help='Full URL for the yum repository')
+    parser.add_argument('-s', '--screenshot_dir', type=str, required=False, help='Directory to store screenshots of failed installs')
 
     args = parser.parse_args()
     composer = CreateLiveTask(args, cmd, profile=args.profile)


### PR DESCRIPTION
This allows our jenkins jobs to specify a screenshot dir under $WORKSPACE/logs so that we can easily capture the screenshot with the run/build.