### PR TITLE
[merged] Add `ostree_remote` config option

### DIFF
--- a/src/py/lorax-http-repo.tmpl
+++ b/src/py/lorax-http-repo.tmpl
@@ -5,7 +5,7 @@ runcmd ostree remote add ostree-mirror --repo=${root}/install/ostree/ --set=gpg-
 runcmd ostree --repo=${root}/install/ostree/ pull --mirror ostree-mirror @OSTREE_REF@
 
 
-append usr/share/anaconda/interactive-defaults.ks "ostreesetup --nogpg --osname=@OSTREE_OSNAME@ --remote=@OSTREE_OSNAME@ --url=file:///install/ostree --ref=@OSTREE_REF@\n"
+append usr/share/anaconda/interactive-defaults.ks "ostreesetup --nogpg --osname=@OSTREE_OSNAME@ --remote=@OSTREE_REMOTE@ --url=file:///install/ostree --ref=@OSTREE_REF@\n"
 append usr/share/anaconda/interactive-defaults.ks "services --disabled cloud-init,cloud-config,cloud-final,cloud-init-local\n"
-append usr/share/anaconda/interactive-defaults.ks "%post --erroronfail\nfn=/etc/ostree/remotes.d/@OSTREE_OSNAME@.conf; if test -f "<%text>${fn}</%text>" && grep -q -e '^url=file:///install/ostree' "<%text>${fn}</%text>"$; then rm "<%text>${fn}</%text>"; fi\n%end\n"
+append usr/share/anaconda/interactive-defaults.ks "%post --erroronfail\nfn=/etc/ostree/remotes.d/@OSTREE_REMOTE@.conf; if test -f "<%text>${fn}</%text>" && grep -q -e '^url=file:///install/ostree' "<%text>${fn}</%text>"$; then rm "<%text>${fn}</%text>"; fi\n%end\n"
 

--- a/src/py/rpmostreecompose/installer.py
+++ b/src/py/rpmostreecompose/installer.py
@@ -154,6 +154,7 @@ CMD ["/bin/sh", "/root/lorax.sh"]
 
         substitutions = {'OSTREE_REF':  self.ref,
                          'OSTREE_OSNAME':  self.os_name,
+                         'OSTREE_REMOTE':  self.ostree_remote,
                          'OS_PRETTY': self.os_pretty_name,
                          'OS_VER': self.release,
                          'OS_VER': self.release,

--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -50,7 +50,7 @@ def _merge_lists(x, y):
 
 class TaskBase(object):
     ATTRS = [ 'workdir', 'rpmostree_cache_dir', 'pkgdatadir',
-              'os_name', 'os_pretty_name', 'ostree_repo',
+              'os_name', 'ostree_remote', 'os_pretty_name', 'ostree_repo',
               'tree_name', 'tree_file', 'arch', 'release', 'ref',
               'yum_baseurl', 'lorax_additional_repos',
               'is_final',
@@ -69,6 +69,7 @@ class TaskBase(object):
         self.rpmostree_cache_dir = None
         self.pkgdatadir = None
         self.os_name = None
+        self.ostree_remote = None
         self.os_pretty_name = None
         self.tree_name = None
         self.tree_file = None
@@ -148,6 +149,8 @@ class TaskBase(object):
             self.ostree_repo = os.environ.get('OSTREE_REPO')
         if not self.ostree_repo:
             self.ostree_repo = self.outputdir + '/repo'
+        if not self.ostree_remote:
+            self.ostree_remote = self.os_name
         release = self.release
         # Check for configdir in attrs, else fallback to dir holding config
         if self.configdir is None:


### PR DESCRIPTION
For [CAHC](https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel)
I want to use the base `centos-atomic-host` osname, but
use `centos-atomic-continuous` as the ostree remote name.