### PR TITLE
[merged] Avoid substituting empty/unset values in kickstart

### DIFF
--- a/src/py/rpmostreecompose/imagefactory.py
+++ b/src/py/rpmostreecompose/imagefactory.py
@@ -328,6 +328,8 @@ class AbstractImageFactoryTask(ImageTaskBase):
         with open(flattened_ks) as f:
             for line in f:
                 for subname, subval in substitutions.iteritems():
+                    if subval is None:
+                        continue
                     line = line.replace('@%s@' % (subname, ), subval)
 
                 # By default, we replace the --url with the local repo

--- a/src/py/rpmostreecompose/installer.py
+++ b/src/py/rpmostreecompose/installer.py
@@ -162,6 +162,8 @@ CMD ["/bin/sh", "/root/lorax.sh"]
                          }
 
         for subname, subval in substitutions.iteritems():
+            if subval is None:
+                continue
             lorax_tmpl = lorax_tmpl.replace('@%s@' % (subname, ), subval)
 
         self.dumpTempMeta(os.path.join(self.workdir, "lorax.tmpl"), lorax_tmpl)


### PR DESCRIPTION
I hit a traceback when trying to use a remote --ostreerepo with
imagefactory.  There's no reason for us to try to substitute values we
haven't computed.