### PR TITLE
installer: Support lorax_rootfs_size

### DIFF
--- a/src/py/rpmostreecompose/installer.py
+++ b/src/py/rpmostreecompose/installer.py
@@ -65,6 +65,8 @@ class InstallerTask(ImageTaskBase):
         os_v = self.release
         lorax_cmd = ['lorax', '--nomacboot', '--add-template=/root/lorax.tmpl',
                      '-p', self.os_pretty_name, '-v', os_v, '-r', os_v]
+        if self.lorax_rootfs_size is not None:
+            lorax_cmd.extend(['--rootfs-size', self.lorax_rootfs_size])
         isolabel = "{0}-{1}-{2}".format(self.os_pretty_name, os_v, self.arch)
         if len(isolabel) > 32:
             isolabel = isolabel[:32].strip()

--- a/src/py/rpmostreecompose/taskbase.py
+++ b/src/py/rpmostreecompose/taskbase.py
@@ -56,6 +56,7 @@ class TaskBase(object):
               'is_final',
               'lorax_exclude_packages',
               'lorax_include_packages',
+              'lorax_rootfs_size',
               'local_overrides', 'http_proxy',
               'selinux', 'configdir', 'docker_os_name',
               'vsphere_product_name', 'vsphere_product_vendor_name',
@@ -81,6 +82,7 @@ class TaskBase(object):
         self.is_final = None
         self.lorax_exclude_packages = None
         self.lorax_include_packages = None
+        self.lorax_rootfs_size = None
         self.local_overrides = None
         self.http_proxy = None
         self.selinux = None


### PR DESCRIPTION
This is necessary for Atomic Workstation, where the content blows
out the default 2GB size.

See https://github.com/rhinstaller/lorax/pull/142
and https://github.com/rhinstaller/lorax/pull/150