### PR TITLE
Make sure OSTREE_PORT is a str after switch to in-built Python webserver

### DIFF
--- a/src/py/rpmostreecompose/imagefactory.py
+++ b/src/py/rpmostreecompose/imagefactory.py
@@ -260,7 +260,7 @@ class AbstractImageFactoryTask(ImageTaskBase):
         substitutions = { 'OSTREE_REF':  self.ref,
                           'OSTREE_OSNAME':  self.os_name}
 
-        substitutions['OSTREE_PORT'] = self.httpd_port
+        substitutions['OSTREE_PORT'] = str(self.httpd_port)
 
         if not self.ostree_repo_is_remote:
             host_ip = getDefaultIP(hostnet=self.virtnetwork)


### PR DESCRIPTION
Small bugfix to remove `TypeError` as `self.httpd_port` is an `int` when using built-in Python webserver to serve a local ostree repo. Unfortunately I still couldn't get building an image to work, the ostree server eventually dies whilst setup within the VM is pulling from the ostree repo.

Understand project is deprecated, but we haven't moved to alternatives yet. In the meantime, we're pointing to an ostree repo on S3 rather than using the same one locally.
